### PR TITLE
fix: webview misplacement under Windows text scaling; font size setting

### DIFF
--- a/docs/RUN-AND-UPDATE.md
+++ b/docs/RUN-AND-UPDATE.md
@@ -1,0 +1,102 @@
+# 執行與更新指南
+
+本文件整理 Multi-AI Chat Desktop 的日常執行與更新流程。詳細背景見 [README.zh-TW.md](../README.zh-TW.md)。
+
+## 前置需求
+
+- Node.js 20+
+- pnpm（本專案鎖定 `pnpm@11`，可用 Corepack：`corepack enable`）
+- Rust stable toolchain（Windows 需 MSVC + Visual Studio Build Tools「Desktop development with C++」）
+- Windows 10/11 通常已內建 WebView2
+
+## 執行方法
+
+### 方法一：直接執行（開發模式）
+
+```sh
+pnpm install
+pnpm build:injected   # 產生 src-tauri/gen/injected 的注入腳本
+pnpm tauri dev        # 第一次 Rust 編譯較久，完成後自動開啟視窗
+```
+
+### 方法二：透過 agent 腳本（有稽核與狀態管理）
+
+```sh
+node scripts/agent/doctor.mjs --json     # 檢查前置環境
+node scripts/agent/launch.mjs --wait --timeout-ms 600000 --json
+node scripts/agent/status.mjs --json --lines 80   # 查狀態，state: "ready" 才算就緒
+node scripts/agent/stop.mjs --json       # 停止
+```
+
+在 Claude Code 中可直接執行 `/launch-multi-ai-chat`，等同上述流程加上前後稽核。
+
+### 方法三：安裝正式版本（非開發用）
+
+到 [Releases](https://github.com/teddashh/multi-ai-chat-desktop/releases/latest) 下載對應平台的安裝檔（Windows `.zip`/`x64-setup.exe`、macOS `.dmg`、Linux `.AppImage`）。
+
+## 更新方法
+
+### 更新原始碼（開發環境）
+
+```sh
+git pull
+pnpm install          # lockfile 有變更時同步 dependencies
+pnpm build:injected   # 注入腳本有變更時必須重建
+pnpm tauri dev
+```
+
+### 更新後驗證
+
+```sh
+pnpm verify   # 一次跑完：build:injected + typecheck + lint + test + agent:verify + adapter 檢查
+```
+
+只想快速檢查可分開跑：
+
+```sh
+pnpm typecheck
+pnpm test
+```
+
+### 更新正式版本（安裝版）
+
+app 內建更新檢查會比對 GitHub 最新 release；有新版時到 Releases 頁下載安裝即可，本機設定與 provider 登入 profile 會保留。
+
+## 產生執行檔
+
+### 本機打包（開發環境）
+
+```sh
+pnpm tauri build      # 自動先建前端與注入腳本，再編譯 Rust release
+```
+
+產物位置：
+
+- 純執行檔：`src-tauri/target/release/*.exe`
+- NSIS 安裝檔：`src-tauri/target/release/bundle/nsis/*-setup.exe`
+
+portable zip（含 `PORTABLE` 標記，停用 app 內更新 UI）：
+
+```sh
+pnpm pack:portable    # 從 src-tauri/target/release 打包到 dist/portable/
+```
+
+注意：本機 build 版本號固定為 `0.0.0`；正式版本號由 CI 從 git tag 注入。
+
+### 正式發佈（三平台，走 CI）
+
+推 `v*` tag 觸發 Release workflow，CI 產出 Windows `.exe`/`.zip`、macOS `.dmg`、Linux `.AppImage` 掛在 draft Release，人工審核後 Publish。完整流程與發佈前檢查見 [RELEASE.md](./RELEASE.md)。
+
+## 常用指令一覽
+
+| 指令 | 用途 |
+|---|---|
+| `pnpm tauri dev` | 開發模式執行 |
+| `pnpm build` | 建置前端（vite） |
+| `pnpm build:injected` | 建置注入腳本 |
+| `pnpm verify` | 完整驗證（提交前建議執行） |
+| `pnpm test` | 跑 vitest 測試 |
+| `pnpm typecheck` | TypeScript 型別檢查 |
+| `pnpm lint` | ESLint |
+| `pnpm tauri build` | 產生執行檔與安裝檔（release） |
+| `pnpm pack:portable` | 打包 portable zip |

--- a/src-tauri/src/webviews.rs
+++ b/src-tauri/src/webviews.rs
@@ -2,13 +2,16 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     io::{self, Write},
-    sync::{Mutex, OnceLock},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Mutex, OnceLock,
+    },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tauri::{
     utils::config::BackgroundThrottlingPolicy,
     webview::{NewWindowResponse, WebviewBuilder},
-    AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, WebviewUrl,
+    AppHandle, Emitter, Manager, PhysicalPosition, PhysicalSize, WebviewUrl,
 };
 use tauri_plugin_opener::OpenerExt;
 
@@ -213,14 +216,35 @@ pub async fn provider_open(
             }
             false
         })
-        .on_new_window(move |url, _features| {
+        .on_new_window(move |url, features| {
             // Challenge auxiliary about: documents are allowed only as in-webview navigation.
             // Keep all non-HTTP(S) popups fail-closed; Turnstile does not require popup windows.
             let allowlisted = adapters::url_allowed_for_provider(&popup_provider, &url)
                 .unwrap_or(false)
                 || adapters::url_allowed_for_sso(&popup_provider, &url).unwrap_or(false);
             match decide_new_window_action(&url, allowlisted) {
-                NewWindowAction::AllowPopup => NewWindowResponse::Allow,
+                // Host popups in our own decorated window: the platform-default popup
+                // (WebView2) is undecorated, so it can't be dragged off the page it covers.
+                // window_features() wires the opener environment, so OAuth flows keep working.
+                NewWindowAction::AllowPopup => {
+                    static POPUP_SEQ: AtomicUsize = AtomicUsize::new(0);
+                    let label =
+                        format!("provider-popup-{}", POPUP_SEQ.fetch_add(1, Ordering::Relaxed));
+                    let builder = tauri::WebviewWindowBuilder::new(
+                        &popup_app,
+                        &label,
+                        WebviewUrl::External("about:blank".parse().expect("static url")),
+                    )
+                    .window_features(features)
+                    .title(url.as_str())
+                    .on_document_title_changed(|window, title| {
+                        let _ = window.set_title(&title);
+                    });
+                    match builder.build() {
+                        Ok(window) => NewWindowResponse::Create { window },
+                        Err(_) => NewWindowResponse::Allow,
+                    }
+                }
                 NewWindowAction::DenySilent => NewWindowResponse::Deny,
                 NewWindowAction::DenyExternal => {
                     if let Some(host) = url.host_str() {
@@ -239,8 +263,8 @@ pub async fn provider_open(
     let webview = window
         .add_child(
             builder,
-            LogicalPosition::new(bounds.x, bounds.y),
-            LogicalSize::new(bounds.width, bounds.height),
+            PhysicalPosition::new(bounds.x as i32, bounds.y as i32),
+            PhysicalSize::new(bounds.width as u32, bounds.height as u32),
         )
         .map_err(|error| error.to_string())?;
     webview.show().map_err(|error| error.to_string())?;
@@ -638,10 +662,18 @@ fn set_webview_bounds<R: tauri::Runtime>(
     webview: &tauri::Webview<R>,
     bounds: &Bounds,
 ) -> Result<(), String> {
+    // 前端傳來的是實體像素（CSS px × devicePixelRatio），必須用 Physical。
+    // 用 Logical 會少乘 WebView2 的頁面縮放（Windows「文字大小」），造成 webview 錯位。
     webview
         .set_bounds(tauri::Rect {
-            position: tauri::Position::Logical(LogicalPosition::new(bounds.x, bounds.y)),
-            size: tauri::Size::Logical(LogicalSize::new(bounds.width, bounds.height)),
+            position: tauri::Position::Physical(PhysicalPosition::new(
+                bounds.x as i32,
+                bounds.y as i32,
+            )),
+            size: tauri::Size::Physical(PhysicalSize::new(
+                bounds.width as u32,
+                bounds.height as u32,
+            )),
         })
         .map_err(|error| error.to_string())
 }

--- a/src-tauri/src/webviews.rs
+++ b/src-tauri/src/webviews.rs
@@ -103,7 +103,7 @@ fn runtime() -> &'static Mutex<ProviderRuntime> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NewWindowAction {
-    /// Platform-native popup (OAuth / allowlisted window.open) — return NewWindowResponse::Allow.
+    /// OAuth / allowlisted window.open hosted in a decorated Tauri window.
     AllowPopup,
     /// Emit nav://blocked + open system browser, then Deny.
     DenyExternal,
@@ -124,6 +124,41 @@ fn decide_new_window_action(url: &tauri::Url, allowlisted: bool) -> NewWindowAct
     NewWindowAction::DenySilent
 }
 
+fn popup_initial_title(url: &tauri::Url) -> &str {
+    url.host_str().unwrap_or("Sign in")
+}
+
+fn physical_bounds(bounds: &Bounds) -> Result<(PhysicalPosition<i32>, PhysicalSize<u32>), String> {
+    fn position(value: f64, name: &str) -> Result<i32, String> {
+        if !value.is_finite() {
+            return Err(format!("invalid webview bounds: {name} must be finite"));
+        }
+        let rounded = value.round();
+        if rounded < i32::MIN as f64 || rounded > i32::MAX as f64 {
+            return Err(format!("invalid webview bounds: {name} is out of range"));
+        }
+        Ok(rounded as i32)
+    }
+
+    fn size(value: f64, name: &str) -> Result<u32, String> {
+        if !value.is_finite() {
+            return Err(format!("invalid webview bounds: {name} must be finite"));
+        }
+        let rounded = value.round();
+        if rounded < 1.0 || rounded > u32::MAX as f64 {
+            return Err(format!(
+                "invalid webview bounds: {name} must round to a positive u32"
+            ));
+        }
+        Ok(rounded as u32)
+    }
+
+    Ok((
+        PhysicalPosition::new(position(bounds.x, "x")?, position(bounds.y, "y")?),
+        PhysicalSize::new(size(bounds.width, "width")?, size(bounds.height, "height")?),
+    ))
+}
+
 #[tauri::command]
 pub async fn provider_open(
     app: AppHandle,
@@ -132,12 +167,13 @@ pub async fn provider_open(
     bounds: Bounds,
 ) -> Result<ProviderState, String> {
     ensure_control_webview(&webview)?;
+    let (position, size) = physical_bounds(&bounds)?;
     let adapter = adapters::get_adapter(&provider)?;
     let label = provider_label(&provider);
     if let Some(webview) = app.get_webview(&label) {
         webview.show().map_err(|error| error.to_string())?;
         webview.set_focus().map_err(|error| error.to_string())?;
-        set_webview_bounds(&webview, &bounds)?;
+        set_webview_bounds(&webview, position, size)?;
         let state = current_state(&provider);
         return Ok(state);
     }
@@ -228,15 +264,17 @@ pub async fn provider_open(
                 // window_features() wires the opener environment, so OAuth flows keep working.
                 NewWindowAction::AllowPopup => {
                     static POPUP_SEQ: AtomicUsize = AtomicUsize::new(0);
-                    let label =
-                        format!("provider-popup-{}", POPUP_SEQ.fetch_add(1, Ordering::Relaxed));
+                    let label = format!(
+                        "provider-popup-{}",
+                        POPUP_SEQ.fetch_add(1, Ordering::Relaxed)
+                    );
                     let builder = tauri::WebviewWindowBuilder::new(
                         &popup_app,
                         &label,
                         WebviewUrl::External("about:blank".parse().expect("static url")),
                     )
                     .window_features(features)
-                    .title(url.as_str())
+                    .title(popup_initial_title(&url))
                     .on_document_title_changed(|window, title| {
                         let _ = window.set_title(&title);
                     });
@@ -261,11 +299,7 @@ pub async fn provider_open(
         });
 
     let webview = window
-        .add_child(
-            builder,
-            PhysicalPosition::new(bounds.x as i32, bounds.y as i32),
-            PhysicalSize::new(bounds.width as u32, bounds.height as u32),
-        )
+        .add_child(builder, position, size)
         .map_err(|error| error.to_string())?;
     webview.show().map_err(|error| error.to_string())?;
     let state = state_with(&provider, "loaded", "unknown", "unknown", false);
@@ -337,11 +371,12 @@ pub async fn provider_set_bounds(
     bounds: Bounds,
 ) -> Result<(), String> {
     ensure_control_webview(&webview)?;
+    let (position, size) = physical_bounds(&bounds)?;
     let label = provider_label(&provider);
     let webview = app
         .get_webview(&label)
         .ok_or_else(|| format!("webview not found: {label}"))?;
-    set_webview_bounds(&webview, &bounds)
+    set_webview_bounds(&webview, position, size)
 }
 
 #[tauri::command]
@@ -660,20 +695,15 @@ fn provider_label(provider: &str) -> String {
 
 fn set_webview_bounds<R: tauri::Runtime>(
     webview: &tauri::Webview<R>,
-    bounds: &Bounds,
+    position: PhysicalPosition<i32>,
+    size: PhysicalSize<u32>,
 ) -> Result<(), String> {
     // 前端傳來的是實體像素（CSS px × devicePixelRatio），必須用 Physical。
     // 用 Logical 會少乘 WebView2 的頁面縮放（Windows「文字大小」），造成 webview 錯位。
     webview
         .set_bounds(tauri::Rect {
-            position: tauri::Position::Physical(PhysicalPosition::new(
-                bounds.x as i32,
-                bounds.y as i32,
-            )),
-            size: tauri::Size::Physical(PhysicalSize::new(
-                bounds.width as u32,
-                bounds.height as u32,
-            )),
+            position: tauri::Position::Physical(position),
+            size: tauri::Size::Physical(size),
         })
         .map_err(|error| error.to_string())
 }
@@ -833,11 +863,14 @@ fn now_ms() -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use tauri::{PhysicalPosition, PhysicalSize};
+
     use super::{
         bridge_resets_on_boot_rotation, challenge_auxiliary_navigation_allowed,
-        decide_new_window_action, provider_uses_permission_shim, runtime,
-        should_reset_bridge_on_boot_rotation, staleness_action, state_with, NewWindowAction,
-        StalenessAction, PROVIDER_BROWSER_ARGS,
+        decide_new_window_action, physical_bounds, popup_initial_title,
+        provider_uses_permission_shim, runtime, should_reset_bridge_on_boot_rotation,
+        staleness_action, state_with, Bounds, NewWindowAction, StalenessAction,
+        PROVIDER_BROWSER_ARGS,
     };
 
     fn url(input: &str) -> tauri::Url {
@@ -897,6 +930,97 @@ mod tests {
             ),
             NewWindowAction::AllowPopup
         );
+    }
+
+    #[test]
+    fn popup_initial_title_never_exposes_oauth_query_parameters() {
+        let oauth =
+            url("https://accounts.google.com/o/oauth2/v2/auth?client_id=secret&state=sensitive");
+        assert_eq!(popup_initial_title(&oauth), "accounts.google.com");
+        assert_eq!(popup_initial_title(&url("about:blank")), "Sign in");
+    }
+
+    #[test]
+    fn physical_bounds_round_valid_values_and_allow_negative_positions() {
+        let (position, size) = physical_bounds(&Bounds {
+            x: -10.4,
+            y: 0.0,
+            width: 640.6,
+            height: 479.5,
+        })
+        .expect("valid bounds should convert");
+
+        assert_eq!(position, PhysicalPosition::new(-10, 0));
+        assert_eq!(size, PhysicalSize::new(641, 480));
+    }
+
+    #[test]
+    fn physical_bounds_reject_non_finite_values() {
+        for field in 0..4 {
+            for invalid in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+                let mut bounds = Bounds {
+                    x: 10.0,
+                    y: 20.0,
+                    width: 640.0,
+                    height: 480.0,
+                };
+                match field {
+                    0 => bounds.x = invalid,
+                    1 => bounds.y = invalid,
+                    2 => bounds.width = invalid,
+                    _ => bounds.height = invalid,
+                }
+                assert!(physical_bounds(&bounds).is_err());
+            }
+        }
+    }
+
+    #[test]
+    fn physical_bounds_reject_invalid_sizes_and_out_of_range_positions() {
+        for invalid_size in [0.0, -1.0, 0.49, u32::MAX as f64 + 1.0] {
+            for bounds in [
+                Bounds {
+                    x: 0.0,
+                    y: 0.0,
+                    width: invalid_size,
+                    height: 480.0,
+                },
+                Bounds {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 640.0,
+                    height: invalid_size,
+                },
+            ] {
+                assert!(physical_bounds(&bounds).is_err());
+            }
+        }
+        for bounds in [
+            Bounds {
+                x: i32::MAX as f64 + 1.0,
+                y: 0.0,
+                width: 640.0,
+                height: 480.0,
+            },
+            Bounds {
+                x: 0.0,
+                y: i32::MIN as f64 - 1.0,
+                width: 640.0,
+                height: 480.0,
+            },
+        ] {
+            assert!(physical_bounds(&bounds).is_err());
+        }
+
+        let (position, size) = physical_bounds(&Bounds {
+            x: i32::MIN as f64,
+            y: i32::MAX as f64,
+            width: 1.0,
+            height: u32::MAX as f64,
+        })
+        .expect("exact integer limits should remain valid");
+        assert_eq!(position, PhysicalPosition::new(i32::MIN, i32::MAX));
+        assert_eq!(size, PhysicalSize::new(1, u32::MAX));
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -408,6 +408,10 @@ export default function App() {
   }, [appSettings.theme]);
 
   useEffect(() => {
+    document.documentElement.style.fontSize = `${appSettings.fontSize}px`;
+  }, [appSettings.fontSize]);
+
+  useEffect(() => {
     localeRef.current = locale;
   }, [locale]);
 

--- a/src/__tests__/focusLayout.test.ts
+++ b/src/__tests__/focusLayout.test.ts
@@ -8,7 +8,7 @@ import {
   nonEmptyRect,
 } from '../ui/focusLayout';
 import { applyPresentationTransitionCommand, waitForPresentationTargetBounds, type PresentationCommandHost } from '../ui/presentationCommands';
-import { normalizeSettings } from '../ui/settingsModel';
+import { DEFAULT_FONT_SIZE, MIN_FONT_SIZE, normalizeSettings } from '../ui/settingsModel';
 
 function rect(width: number, height: number): DOMRectReadOnly {
   return { x: 10, y: 20, width, height, top: 20, left: 10, right: 10 + width, bottom: 20 + height, toJSON: () => ({}) };
@@ -126,12 +126,12 @@ describe('focus layout helpers', () => {
     expect(normalizeSettings({ columnWidths: { left: 500, right: 320 } }).focusPaneWidth).toBe(500);
   });
 
-  it('normalizes font size: minimum 10, no upper limit, invalid falls back to default', () => {
-    expect(normalizeSettings({}).fontSize).toBe(16);
+  it('normalizes font size: configured minimum, no upper limit, invalid falls back to default', () => {
+    expect(normalizeSettings({}).fontSize).toBe(DEFAULT_FONT_SIZE);
     expect(normalizeSettings({ fontSize: 18 }).fontSize).toBe(18);
     expect(normalizeSettings({ fontSize: 72 }).fontSize).toBe(72);
-    expect(normalizeSettings({ fontSize: 8 }).fontSize).toBe(16);
-    expect(normalizeSettings({ fontSize: '18' }).fontSize).toBe(16);
-    expect(normalizeSettings({ fontSize: Number.NaN }).fontSize).toBe(16);
+    expect(normalizeSettings({ fontSize: MIN_FONT_SIZE - 1 }).fontSize).toBe(DEFAULT_FONT_SIZE);
+    expect(normalizeSettings({ fontSize: '18' }).fontSize).toBe(DEFAULT_FONT_SIZE);
+    expect(normalizeSettings({ fontSize: Number.NaN }).fontSize).toBe(DEFAULT_FONT_SIZE);
   });
 });

--- a/src/__tests__/focusLayout.test.ts
+++ b/src/__tests__/focusLayout.test.ts
@@ -125,4 +125,13 @@ describe('focus layout helpers', () => {
     expect(normalizeSettings({ focusPaneWidth: 250 }).focusPaneWidth).toBe(420);
     expect(normalizeSettings({ columnWidths: { left: 500, right: 320 } }).focusPaneWidth).toBe(500);
   });
+
+  it('normalizes font size: minimum 10, no upper limit, invalid falls back to default', () => {
+    expect(normalizeSettings({}).fontSize).toBe(16);
+    expect(normalizeSettings({ fontSize: 18 }).fontSize).toBe(18);
+    expect(normalizeSettings({ fontSize: 72 }).fontSize).toBe(72);
+    expect(normalizeSettings({ fontSize: 8 }).fontSize).toBe(16);
+    expect(normalizeSettings({ fontSize: '18' }).fontSize).toBe(16);
+    expect(normalizeSettings({ fontSize: Number.NaN }).fontSize).toBe(16);
+  });
 });

--- a/src/__tests__/serialTaskQueue.test.ts
+++ b/src/__tests__/serialTaskQueue.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSerialTaskQueue } from '../ui/serialTaskQueue';
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('serial task queue', () => {
+  it('does not start a newer settings write until the previous write settles', async () => {
+    const enqueue = createSerialTaskQueue();
+    const firstWrite = deferred<void>();
+    const writes: number[] = [];
+
+    const first = enqueue(async () => {
+      writes.push(18);
+      await firstWrite.promise;
+    });
+    const secondTask = vi.fn(async () => {
+      writes.push(20);
+    });
+    const second = enqueue(secondTask);
+
+    await vi.waitFor(() => expect(writes).toEqual([18]));
+    expect(secondTask).not.toHaveBeenCalled();
+
+    firstWrite.resolve();
+    await Promise.all([first, second]);
+    expect(writes).toEqual([18, 20]);
+  });
+
+  it('continues with the next task after a failed write', async () => {
+    const enqueue = createSerialTaskQueue();
+    const firstWrite = deferred<void>();
+    const writes: number[] = [];
+
+    const first = enqueue(async () => {
+      writes.push(18);
+      await firstWrite.promise;
+    });
+    const second = enqueue(async () => {
+      writes.push(20);
+    });
+
+    firstWrite.reject(new Error('write failed'));
+    await expect(first).rejects.toThrow('write failed');
+    await expect(second).resolves.toBeUndefined();
+    expect(writes).toEqual([18, 20]);
+  });
+});

--- a/src/__tests__/settingsPersistence.test.ts
+++ b/src/__tests__/settingsPersistence.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSettingsPersistence } from '../ui/settingsPersistence';
+import { defaultSettings, type AppSettings } from '../ui/settingsModel';
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function storeWith(settings: AppSettings) {
+  let persisted = settings;
+  const commit = async (next: unknown) => {
+    persisted = next as AppSettings;
+  };
+  return {
+    get: vi.fn(async () => persisted),
+    set: vi.fn(commit),
+    commit,
+  };
+}
+
+describe('settings persistence', () => {
+  it('persists rapid font-size updates in order so the last input wins', async () => {
+    const initial = defaultSettings();
+    const store = storeWith(initial);
+    const firstWrite = deferred<void>();
+    store.set.mockImplementationOnce(async (next: unknown) => {
+      await firstWrite.promise;
+      await store.commit(next);
+    });
+    const persistence = createSettingsPersistence(store);
+    persistence.replaceCurrent(initial);
+
+    const first = persistence.update({ fontSize: 18 });
+    const second = persistence.update({ fontSize: 20 });
+
+    await vi.waitFor(() => expect(store.set).toHaveBeenCalledTimes(1));
+    expect((store.set.mock.calls[0][0] as AppSettings).fontSize).toBe(18);
+    firstWrite.resolve();
+    await Promise.all([first, second]);
+
+    expect(store.set.mock.calls.map(([settings]) => (settings as AppSettings).fontSize)).toEqual([18, 20]);
+    expect(persistence.current()?.fontSize).toBe(20);
+  });
+
+  it('continues with the latest update after an earlier write fails', async () => {
+    const initial = defaultSettings();
+    const store = storeWith(initial);
+    store.set.mockRejectedValueOnce(new Error('write failed'));
+    const persistence = createSettingsPersistence(store);
+    persistence.replaceCurrent(initial);
+
+    const first = persistence.update({ fontSize: 18 });
+    const second = persistence.update({ fontSize: 20 });
+
+    await expect(first).rejects.toThrow('write failed');
+    await expect(second).resolves.toMatchObject({ fontSize: 20 });
+    expect(store.set).toHaveBeenCalledTimes(2);
+    expect(persistence.current()?.fontSize).toBe(20);
+  });
+
+  it('builds a queued patch from the most recently committed settings', async () => {
+    const initial = defaultSettings();
+    const store = storeWith(initial);
+    const firstWrite = deferred<void>();
+    store.set.mockImplementationOnce(async () => firstWrite.promise);
+    const persistence = createSettingsPersistence(store);
+    persistence.replaceCurrent(initial);
+
+    const language = persistence.update({ language: 'ja' });
+    const fontSize = persistence.update({ fontSize: 20 });
+    await vi.waitFor(() => expect(store.set).toHaveBeenCalledTimes(1));
+    firstWrite.resolve();
+    await Promise.all([language, fontSize]);
+
+    expect(store.set.mock.calls[1][0]).toMatchObject({ language: 'ja', fontSize: 20 });
+  });
+
+  it('waits for a pending write before loading settings again', async () => {
+    const initial = defaultSettings();
+    const store = storeWith(initial);
+    const firstWrite = deferred<void>();
+    store.set.mockImplementationOnce(async (next: unknown) => {
+      await firstWrite.promise;
+      await store.commit(next);
+    });
+    const persistence = createSettingsPersistence(store);
+    persistence.replaceCurrent(initial);
+
+    const update = persistence.update({ fontSize: 18 });
+    const load = persistence.load();
+    await vi.waitFor(() => expect(store.set).toHaveBeenCalledTimes(1));
+    expect(store.get).not.toHaveBeenCalled();
+
+    firstWrite.resolve();
+    await update;
+    await expect(load).resolves.toMatchObject({ fontSize: 18 });
+    expect(store.get).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/trailingDebounce.test.ts
+++ b/src/__tests__/trailingDebounce.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createTrailingDebounce } from '../ui/trailingDebounce';
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('trailing debounce', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('coalesces rapid updates and runs only the latest value', async () => {
+    vi.useFakeTimers();
+    const callback = vi.fn();
+    const debounce = createTrailingDebounce(callback, 250);
+
+    debounce.schedule(18);
+    vi.advanceTimersByTime(100);
+    debounce.schedule(20);
+    vi.advanceTimersByTime(249);
+    expect(callback).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith(20);
+  });
+
+  it('can flush on close or cancel when Save persists the full draft', async () => {
+    vi.useFakeTimers();
+    const callback = vi.fn();
+    const debounce = createTrailingDebounce(callback, 250);
+
+    debounce.schedule(18);
+    await debounce.flush();
+    expect(callback).toHaveBeenCalledWith(18);
+
+    debounce.schedule(20);
+    debounce.cancel();
+    vi.runAllTimers();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for async persistence and exposes a close-time failure', async () => {
+    vi.useFakeTimers();
+    const write = deferred<void>();
+    const callback = vi.fn(() => write.promise);
+    const debounce = createTrailingDebounce(callback, 250);
+    debounce.schedule(20);
+
+    const flush = debounce.flush();
+    let settled = false;
+    void flush.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    write.reject(new Error('write failed'));
+    await expect(flush).rejects.toThrow('write failed');
+    await expect(debounce.flush()).resolves.toBeUndefined();
+  });
+
+  it('starts a newer callback even while the previous persistence is pending', async () => {
+    vi.useFakeTimers();
+    const firstWrite = deferred<void>();
+    const callback = vi.fn((value: number) => (value === 18 ? firstWrite.promise : Promise.resolve()));
+    const debounce = createTrailingDebounce(callback, 250);
+
+    debounce.schedule(18);
+    const first = debounce.flush();
+    debounce.schedule(20);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(callback.mock.calls.map(([value]) => value)).toEqual([18, 20]);
+    firstWrite.resolve();
+    await first;
+  });
+});

--- a/src/host/index.ts
+++ b/src/host/index.ts
@@ -17,12 +17,17 @@ export interface NavBlockedPayload {
   host: string;
 }
 
-const toBounds = (rect: DOMRectReadOnly) => ({
-  x: Math.round(rect.x),
-  y: Math.round(rect.y),
-  width: Math.round(rect.width),
-  height: Math.round(rect.height),
-});
+// CSS px × devicePixelRatio = 實體像素。dpr 已包含 WebView2 頁面縮放
+// （Windows「文字大小」會變成 ZoomFactor），Logical 座標會少乘這個縮放而錯位。
+const toBounds = (rect: DOMRectReadOnly) => {
+  const dpr = globalThis.devicePixelRatio || 1;
+  return {
+    x: Math.round(rect.x * dpr),
+    y: Math.round(rect.y * dpr),
+    width: Math.round(rect.width * dpr),
+    height: Math.round(rect.height * dpr),
+  };
+};
 
 const SNAPSHOT_ID_RE = /^[A-Za-z0-9._-]{1,80}$/;
 

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -192,6 +192,7 @@ export const de: Record<I18nKey, string> = {
   'settings.themeLight': 'Hell',
   'settings.themeDark': 'Dunkel',
   'settings.themeAiSister': 'AI-Sister Gedenkausgabe',
+  'settings.fontSize': 'Schriftgröße',
   'theme.aiSister.badge': 'Finale AI-Sister Gedenkausgabe',
   'theme.aiSister.title': 'AI-Sister Gedenkausgabe',
   'theme.aiSister.subtitle': 'Vier Stimmen, eine letzte Runde.',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -190,6 +190,7 @@ export const en: Record<I18nKey, string> = {
   'settings.themeLight': 'Light',
   'settings.themeDark': 'Dark',
   'settings.themeAiSister': 'AI-Sister Commemorative Edition',
+  'settings.fontSize': 'Font size',
   'theme.aiSister.badge': 'Final commemorative edition',
   'theme.aiSister.title': 'AI-Sister Commemorative Edition',
   'theme.aiSister.subtitle': 'Four voices, one last round.',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -192,6 +192,7 @@ export const ja: Record<I18nKey, string> = {
   'settings.themeLight': 'ライト',
   'settings.themeDark': 'ダーク',
   'settings.themeAiSister': 'AI-Sister 記念版',
+  'settings.fontSize': '文字サイズ',
   'theme.aiSister.badge': 'AI-Sister 最終記念版',
   'theme.aiSister.title': 'AI-Sister 記念版',
   'theme.aiSister.subtitle': '4人の声で、最後のラウンドへ。',

--- a/src/i18n/keys.ts
+++ b/src/i18n/keys.ts
@@ -174,6 +174,7 @@ export const I18N_KEYS = [
   'settings.themeLight',
   'settings.themeDark',
   'settings.themeAiSister',
+  'settings.fontSize',
   'theme.aiSister.badge',
   'theme.aiSister.title',
   'theme.aiSister.subtitle',

--- a/src/i18n/zh-TW.ts
+++ b/src/i18n/zh-TW.ts
@@ -181,6 +181,7 @@ export const zhTW: Record<I18nKey, string> = {
   'settings.themeLight': '淺色',
   'settings.themeDark': '深色',
   'settings.themeAiSister': 'AI-Sister 紀念版',
+  'settings.fontSize': '字體大小',
   'theme.aiSister.badge': 'AI-Sister 最終紀念版',
   'theme.aiSister.title': 'AI-Sister 紀念版',
   'theme.aiSister.subtitle': '四位角色，一起完成最後一輪。',

--- a/src/ui/ConversationSidebar.tsx
+++ b/src/ui/ConversationSidebar.tsx
@@ -70,7 +70,7 @@ export function ConversationSidebar({
 
       {!collapsed ? (
         <div className="flex min-h-0 flex-1 flex-col px-2 pb-2">
-          <h2 className="px-1 pb-2 text-[11px] font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">{labels.history}</h2>
+          <h2 className="px-1 pb-2 text-[0.6875rem] font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">{labels.history}</h2>
           <div className="min-h-0 flex-1 overflow-auto">
             {sessions.length === 0 ? (
               <div className="px-2 py-3 text-xs text-zinc-500 dark:text-zinc-400">{labels.empty}</div>
@@ -92,7 +92,7 @@ export function ConversationSidebar({
                       <span className="block truncate text-xs font-medium">
                         {session.title === DEFAULT_CONVERSATION_SESSION_TITLE ? labels.newConversation : session.title}
                       </span>
-                      <span className="mt-1 block text-[10px] text-zinc-500 dark:text-zinc-400">
+                      <span className="mt-1 block text-[0.625rem] text-zinc-500 dark:text-zinc-400">
                         {new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }).format(session.updatedAt)}
                       </span>
                     </button>

--- a/src/ui/FocusPane.tsx
+++ b/src/ui/FocusPane.tsx
@@ -251,7 +251,6 @@ function FocusStage({
 
   return (
     <section
-      ref={setCenterStageRef}
       className="ai-sister-focus-stage flex min-h-[280px] flex-1 flex-col overflow-hidden border border-sky-300 dark:border-sky-900 bg-zinc-50 dark:bg-zinc-900"
       onPointerDownCapture={() => onManualFocusControl(provider)}
     >
@@ -327,6 +326,8 @@ function FocusStage({
           </div>
         </div>
       </div>
+      {/* WebView 以此區域定位，讓上方標題列（含「文字檢視」返回鈕）保持可見 */}
+      <div ref={setCenterStageRef} className="flex min-h-0 flex-1 flex-col">
       {state.adapter === 'broken' ? (
         <div className="border-b border-red-300 dark:border-red-900 bg-red-50 dark:bg-red-950 px-3 py-2 text-xs text-red-800 dark:text-red-200">{t('provider.adapterBroken')}</div>
       ) : null}
@@ -369,6 +370,7 @@ function FocusStage({
           {hidden ? t('provider.nativeWebviewHidden') : t('provider.nativeWebviewCentered')}
         </div>
       ) : null}
+      </div>
     </section>
   );
 }
@@ -431,7 +433,7 @@ function StatusStrip({
     <section aria-labelledby="provider-connections-title" className="ai-sister-connections mt-3 shrink-0 overflow-x-auto overflow-y-hidden rounded border border-zinc-200 bg-white px-2 py-2 dark:border-zinc-800 dark:bg-zinc-950">
       <div className="mb-2 flex items-baseline justify-between gap-3 px-0.5">
         <h2 id="provider-connections-title" className="text-xs font-semibold text-zinc-800 dark:text-zinc-200">{t('provider.connections')}</h2>
-        <span className="text-[11px] text-zinc-500 dark:text-zinc-400">{t('provider.connectionsHint')}</span>
+        <span className="text-[0.6875rem] text-zinc-500 dark:text-zinc-400">{t('provider.connectionsHint')}</span>
       </div>
       <div className="ai-sister-connection-grid grid grid-cols-4 gap-1.5">
         {PROVIDERS.map((provider) => (
@@ -495,7 +497,7 @@ function StatusStripItem({
           <span className="block truncate text-xs font-medium text-zinc-900 dark:text-zinc-100">{AI_PROVIDERS[provider].name}</span>
           <span className="mt-1 flex min-w-0 items-center gap-1">
             <span className={`h-2 w-2 shrink-0 rounded-full ${status.dotClassName}`} aria-hidden="true" />
-            <span className={`min-w-0 truncate text-[11px] ${status.className}`}>{openingProvider === provider ? t('connection.connecting') : status.label}</span>
+            <span className={`min-w-0 truncate text-[0.6875rem] ${status.className}`}>{openingProvider === provider ? t('connection.connecting') : status.label}</span>
           </span>
         </span>
       </span>
@@ -510,14 +512,14 @@ export function AdapterAccessPanel({ id, summary }: { id: string; summary: Adapt
     <section id={id} className="border-b border-sky-300 dark:border-sky-900 bg-sky-50 dark:bg-sky-950/30 px-3 py-3 text-xs text-zinc-700 dark:text-zinc-300">
       <div className="mb-2 flex items-center justify-between gap-2">
         <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">{t('provider.access.heading')}</h3>
-        <span className="shrink-0 text-[11px] text-sky-700 dark:text-sky-200">{summary.providerName}</span>
+        <span className="shrink-0 text-[0.6875rem] text-sky-700 dark:text-sky-200">{summary.providerName}</span>
       </div>
       <div className="grid gap-3">
         <PermissionGroup title={t('provider.access.readTitle')} lines={summary.reads} />
         <PermissionGroup title={t('provider.access.writeTitle')} lines={summary.writes} />
         <PermissionGroup title={t('provider.access.cannotTitle')} lines={summary.cannot} />
       </div>
-      {summary.note ? <p className="mt-3 border-t border-sky-300 dark:border-sky-900 pt-2 text-[11px] leading-relaxed text-zinc-500 dark:text-zinc-500">{summary.note}</p> : null}
+      {summary.note ? <p className="mt-3 border-t border-sky-300 dark:border-sky-900 pt-2 text-[0.6875rem] leading-relaxed text-zinc-500 dark:text-zinc-500">{summary.note}</p> : null}
     </section>
   );
 }
@@ -534,7 +536,7 @@ function PermissionGroup({ title, lines }: { title: string; lines: AdapterPermis
               <ul className="mt-1 space-y-1 border-l border-zinc-300 dark:border-zinc-700 pl-2">
                 {line.selectors.map((selector) => (
                   <li key={selector}>
-                    <code className="break-all text-[11px] text-sky-700 dark:text-sky-200">{selector}</code>
+                    <code className="break-all text-[0.6875rem] text-sky-700 dark:text-sky-200">{selector}</code>
                   </li>
                 ))}
               </ul>

--- a/src/ui/PresetCatalog.tsx
+++ b/src/ui/PresetCatalog.tsx
@@ -49,7 +49,7 @@ export function PresetCatalog({
             <div className="font-semibold text-sky-900 dark:text-sky-100">{t(detailPreset.displayNameKey, locale)}</div>
             <p className="mt-1 leading-relaxed text-zinc-700 dark:text-zinc-300">{t(detailPreset.descriptionKey, locale)}</p>
           </div>
-          <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[11px] text-zinc-600 dark:bg-zinc-900 dark:text-zinc-300">
+          <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[0.6875rem] text-zinc-600 dark:bg-zinc-900 dark:text-zinc-300">
             {t(detailPreset.costLabelKey, locale)}
           </span>
         </div>
@@ -100,7 +100,7 @@ function renderPresetGrid({
               <span className="truncate text-sm font-semibold">{displayName}</span>
               {readiness ? (
                 <span
-                  className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium ${
+                  className={`shrink-0 rounded-full px-2 py-0.5 text-[0.6875rem] font-medium ${
                     readiness.ready
                       ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-200'
                       : 'bg-zinc-200 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300'
@@ -110,7 +110,7 @@ function renderPresetGrid({
                 </span>
               ) : null}
             </span>
-            {preset.metaKey ? <span className="mt-1 text-[11px] leading-none text-zinc-500 dark:text-zinc-400">{t(preset.metaKey, locale)}</span> : null}
+            {preset.metaKey ? <span className="mt-1 text-[0.6875rem] leading-none text-zinc-500 dark:text-zinc-400">{t(preset.metaKey, locale)}</span> : null}
           </button>
         );
       })}

--- a/src/ui/ProcessTrace.tsx
+++ b/src/ui/ProcessTrace.tsx
@@ -30,8 +30,8 @@ export function ProcessTrace({
     <>
       <section aria-label={t('processTrace.title', locale)} className="ai-sister-process-trace mt-2 shrink-0 overflow-hidden rounded border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900">
         <div className="flex items-center justify-between gap-3 border-b border-zinc-200 px-2.5 py-1.5 dark:border-zinc-800">
-          <h2 className="text-[11px] font-semibold uppercase text-zinc-700 dark:text-zinc-300">{t('processTrace.title', locale)}</h2>
-          <div className="min-w-0 truncate text-right text-[11px] text-sky-700 dark:text-sky-200">{trace.currentStatus || t('processTrace.settled', locale)}</div>
+          <h2 className="text-[0.6875rem] font-semibold uppercase text-zinc-700 dark:text-zinc-300">{t('processTrace.title', locale)}</h2>
+          <div className="min-w-0 truncate text-right text-[0.6875rem] text-sky-700 dark:text-sky-200">{trace.currentStatus || t('processTrace.settled', locale)}</div>
         </div>
         {trace.steps.length > 0 ? (
           <ol className="max-h-36 divide-y divide-zinc-200 overflow-auto dark:divide-zinc-800">
@@ -52,7 +52,7 @@ export function ProcessTrace({
                     <span className={`h-2 w-2 rounded-full ${statusDotClass(step.status)}`} />
                     {step.provider ? <AiSisterAvatar provider={step.provider} size="xs" active={step.status === 'active'} /> : null}
                   </span>
-                  <span className={`truncate text-[11px] font-medium uppercase ${statusClass(step.status)}`}>{statusLabel(step.status, locale)}</span>
+                  <span className={`truncate text-[0.6875rem] font-medium uppercase ${statusClass(step.status)}`}>{statusLabel(step.status, locale)}</span>
                   <span className="min-w-0 truncate text-zinc-800 dark:text-zinc-200">
                     <span className="font-medium">{step.label}</span>
                     {step.detail ? <span className="text-zinc-500 dark:text-zinc-400"> — {step.detail}</span> : null}

--- a/src/ui/SettingsModal.tsx
+++ b/src/ui/SettingsModal.tsx
@@ -21,6 +21,7 @@ import { buildDebugBundle, debugBundleFilename } from '../diagnostics/debugBundl
 import { useEventLog } from './useEventLog';
 import { ModalDialog } from './ModalDialog';
 import { createSettingsPersistence } from './settingsPersistence';
+import { createTrailingDebounce, type TrailingDebounce } from './trailingDebounce';
 
 const PROVIDERS = Object.keys(AI_PROVIDERS) as AIProvider[];
 
@@ -35,6 +36,11 @@ type UpdateCheckState =
 interface SettingsError {
   messageKey: 'settings.loadFailed' | 'settings.saveFailed';
   detail?: string;
+}
+
+interface PendingFontSizeUpdate {
+  fontSize: number;
+  updateSeq: number;
 }
 
 export function SettingsModal({
@@ -63,6 +69,7 @@ export function SettingsModal({
   const [updateCheck, setUpdateCheck] = useState<UpdateCheckState>({ status: 'idle' });
   const closeTimerRef = useRef<number | undefined>();
   const settingsPersistenceRef = useRef(createSettingsPersistence(host.settings));
+  const fontSizeDebounceRef = useRef<TrailingDebounce<PendingFontSizeUpdate> | undefined>(undefined);
   const modalSessionRef = useRef(0);
   const draftUpdateSeqRef = useRef(0);
   const languageUpdateSeqRef = useRef(0);
@@ -79,6 +86,7 @@ export function SettingsModal({
     }
     let disposed = false;
     setDraft(undefined);
+    fontSizeDebounceRef.current?.cancel();
     setFontSizeText(undefined);
     setSaved(false);
     setSaving(false);
@@ -118,6 +126,7 @@ export function SettingsModal({
   useEffect(
     () => () => {
       if (closeTimerRef.current !== undefined) window.clearTimeout(closeTimerRef.current);
+      fontSizeDebounceRef.current?.cancel();
     },
     [],
   );
@@ -167,11 +176,8 @@ export function SettingsModal({
     }
   };
 
-  const updateFontSize = async (fontSize: number) => {
+  const persistFontSize = async ({ fontSize, updateSeq }: PendingFontSizeUpdate) => {
     const modalSession = modalSessionRef.current;
-    const updateSeq = ++fontSizeUpdateSeqRef.current;
-    setError(undefined);
-    updateDraft({ fontSize });
     try {
       const next = await persistSettingsPatch({ fontSize });
       onSaved(next);
@@ -179,8 +185,31 @@ export function SettingsModal({
     } catch (reason) {
       if (updateSeq === fontSizeUpdateSeqRef.current && modalSession === modalSessionRef.current) {
         updateDraft({ fontSize: settingsPersistenceRef.current.current()?.fontSize ?? DEFAULT_FONT_SIZE });
+        setFontSizeText(undefined);
         setError({ messageKey: 'settings.saveFailed', detail: errorDetail(reason) });
       }
+      throw reason;
+    }
+  };
+
+  if (!fontSizeDebounceRef.current) {
+    fontSizeDebounceRef.current = createTrailingDebounce((update) => persistFontSize(update), 250);
+  }
+
+  const scheduleFontSizeUpdate = (fontSize: number) => {
+    const updateSeq = ++fontSizeUpdateSeqRef.current;
+    setError(undefined);
+    updateDraft({ fontSize });
+    fontSizeDebounceRef.current?.schedule({ fontSize, updateSeq });
+  };
+
+  const closeSettings = async () => {
+    const modalSession = modalSessionRef.current;
+    try {
+      await fontSizeDebounceRef.current?.flush();
+      if (modalSession === modalSessionRef.current) onClose();
+    } catch {
+      // persistFontSize already restored the last persisted value and exposed the error.
     }
   };
 
@@ -188,8 +217,9 @@ export function SettingsModal({
     if (!draft) return;
     const modalSession = modalSessionRef.current;
     const draftUpdateSeq = draftUpdateSeqRef.current;
-    languageUpdateSeqRef.current += 1;
+    const languageUpdateSeq = ++languageUpdateSeqRef.current;
     fontSizeUpdateSeqRef.current += 1;
+    fontSizeDebounceRef.current?.cancel();
     setSaving(true);
     setError(undefined);
     try {
@@ -205,8 +235,10 @@ export function SettingsModal({
         closeTimerRef.current = window.setTimeout(onClose, 400);
       }
     } catch (reason) {
-      setLanguage(settingsPersistenceRef.current.current()?.language ?? 'system');
-      if (modalSession === modalSessionRef.current) {
+      if (languageUpdateSeq === languageUpdateSeqRef.current) {
+        setLanguage(settingsPersistenceRef.current.current()?.language ?? 'system');
+      }
+      if (modalSession === modalSessionRef.current && draftUpdateSeq === draftUpdateSeqRef.current) {
         setError({ messageKey: 'settings.saveFailed', detail: errorDetail(reason) });
       }
     } finally {
@@ -236,13 +268,13 @@ export function SettingsModal({
   return (
     <ModalDialog
       titleId="settings-title"
-      onEscape={onClose}
-      onBackdrop={onClose}
+      onEscape={closeSettings}
+      onBackdrop={closeSettings}
       panelClassName="max-h-[92vh] w-full max-w-2xl overflow-auto rounded-lg border border-zinc-300 bg-white p-5 shadow-2xl dark:border-zinc-700 dark:bg-zinc-950"
     >
         <div className="mb-4 flex items-center justify-between border-b border-zinc-200 dark:border-zinc-800 pb-3">
           <h2 id="settings-title" className="text-base font-semibold text-zinc-900 dark:text-zinc-100">{t('settings.title')}</h2>
-          <button type="button" className="border border-zinc-300 dark:border-zinc-700 px-2 py-1 text-xs text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800" onClick={onClose}>
+          <button type="button" className="border border-zinc-300 dark:border-zinc-700 px-2 py-1 text-xs text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800" onClick={closeSettings}>
             {t('settings.close')}
           </button>
         </div>
@@ -296,7 +328,7 @@ export function SettingsModal({
                     const text = event.target.value;
                     setFontSizeText(text);
                     const value = Number(text);
-                    if (Number.isFinite(value) && value >= MIN_FONT_SIZE) void updateFontSize(value);
+                    if (Number.isFinite(value) && value >= MIN_FONT_SIZE) scheduleFontSizeUpdate(value);
                   }}
                   onBlur={() => setFontSizeText(undefined)}
                   className="w-full border border-zinc-300 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900 px-2 py-1.5 text-sm text-zinc-900 dark:text-zinc-100 outline-none focus:border-sky-500 dark:focus:border-sky-600"
@@ -446,7 +478,7 @@ export function SettingsModal({
             </button>
           </div>
           <div className="flex items-center justify-end gap-2">
-            <button type="button" className="px-3 py-1.5 text-sm text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100" onClick={onClose}>
+            <button type="button" className="px-3 py-1.5 text-sm text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100" onClick={closeSettings}>
               {t('settings.cancel')}
             </button>
             <button

--- a/src/ui/SettingsModal.tsx
+++ b/src/ui/SettingsModal.tsx
@@ -6,7 +6,7 @@ import { AdapterAccessPanel } from './FocusPane';
 import { useI18n } from '../i18n/context';
 import { formatI18n } from '../i18n/t';
 import type { PresentationByProvider } from './presentation';
-import { type AppSettings, DEFAULT_FONT_SIZE, MIN_FONT_SIZE, mergeSettings, normalizeSettings } from './settingsModel';
+import { type AppSettings, DEFAULT_FONT_SIZE, MIN_FONT_SIZE, normalizeSettings } from './settingsModel';
 import { compareVersions, fetchLatestRelease } from './updateCheck';
 import { host } from '../host';
 import {
@@ -20,6 +20,7 @@ import {
 import { buildDebugBundle, debugBundleFilename } from '../diagnostics/debugBundle';
 import { useEventLog } from './useEventLog';
 import { ModalDialog } from './ModalDialog';
+import { createSettingsPersistence } from './settingsPersistence';
 
 const PROVIDERS = Object.keys(AI_PROVIDERS) as AIProvider[];
 
@@ -57,14 +58,20 @@ export function SettingsModal({
   const [draft, setDraft] = useState<AppSettings | undefined>();
   const [fontSizeText, setFontSizeText] = useState<string | undefined>();
   const [saved, setSaved] = useState(false);
+  const [saving, setSaving] = useState(false);
   const [error, setError] = useState<SettingsError | undefined>();
   const [updateCheck, setUpdateCheck] = useState<UpdateCheckState>({ status: 'idle' });
-  const loadedRef = useRef<AppSettings | undefined>();
   const closeTimerRef = useRef<number | undefined>();
+  const settingsPersistenceRef = useRef(createSettingsPersistence(host.settings));
+  const modalSessionRef = useRef(0);
+  const draftUpdateSeqRef = useRef(0);
+  const languageUpdateSeqRef = useRef(0);
+  const fontSizeUpdateSeqRef = useRef(0);
   const liveRef = useRef({ openProviders, focusPaneWidth, presentation });
   liveRef.current = { openProviders, focusPaneWidth, presentation };
 
   useEffect(() => {
+    const modalSession = ++modalSessionRef.current;
     if (!open) return;
     if (closeTimerRef.current !== undefined) {
       window.clearTimeout(closeTimerRef.current);
@@ -74,15 +81,15 @@ export function SettingsModal({
     setDraft(undefined);
     setFontSizeText(undefined);
     setSaved(false);
+    setSaving(false);
     setError(undefined);
     setUpdateCheck({ status: 'idle' });
-    void host.settings
-      .get()
-      .then((value) => {
-        if (disposed) return;
-        const loaded = normalizeSettings(value);
+    void settingsPersistenceRef.current
+      .load()
+      .then((loaded) => {
+        if (disposed || modalSession !== modalSessionRef.current) return;
         const live = liveRef.current;
-        loadedRef.current = loaded;
+        setError(undefined);
         setDraft({
           ...loaded,
           openProviders: live.openProviders,
@@ -91,11 +98,11 @@ export function SettingsModal({
         });
       })
       .catch((reason: unknown) => {
-        if (disposed) return;
+        if (disposed || modalSession !== modalSessionRef.current) return;
         setError({ messageKey: 'settings.loadFailed', detail: errorDetail(reason) });
         const fallback = normalizeSettings({});
         const live = liveRef.current;
-        loadedRef.current = fallback;
+        settingsPersistenceRef.current.replaceCurrent(fallback);
         setDraft({
           ...fallback,
           openProviders: live.openProviders,
@@ -118,70 +125,92 @@ export function SettingsModal({
   if (!open) return null;
 
   const updateDraft = (patch: Partial<AppSettings>) => {
+    draftUpdateSeqRef.current += 1;
+    setSaved(false);
+    if (closeTimerRef.current !== undefined) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = undefined;
+    }
     setDraft((current) => (current ? { ...current, ...patch } : current));
   };
 
+  const persistSettingsPatch = (patch: Partial<AppSettings>): Promise<AppSettings> =>
+    settingsPersistenceRef.current.update(() => {
+      const live = liveRef.current;
+      return {
+        ...patch,
+        openProviders: live.openProviders,
+        focusPaneWidth: live.focusPaneWidth,
+        presentation: live.presentation,
+      };
+    });
+
   const updateLanguage = async (language: AppSettings['language']) => {
-    const previousLanguage = loadedRef.current?.language ?? 'system';
+    const modalSession = modalSessionRef.current;
+    const updateSeq = ++languageUpdateSeqRef.current;
     setError(undefined);
     updateDraft({ language });
     setLanguage(language);
-    const live = liveRef.current;
-    const next = mergeSettings(loadedRef.current, {
-      language,
-      openProviders: live.openProviders,
-      focusPaneWidth: live.focusPaneWidth,
-      presentation: live.presentation,
-    });
     try {
-      await host.settings.set(next);
-      loadedRef.current = next;
+      const next = await persistSettingsPatch({ language });
       onSaved(next);
+      if (modalSession === modalSessionRef.current) setError(undefined);
     } catch (reason) {
-      updateDraft({ language: previousLanguage });
-      setLanguage(previousLanguage);
-      setError({ messageKey: 'settings.saveFailed', detail: errorDetail(reason) });
+      if (updateSeq === languageUpdateSeqRef.current) {
+        const persistedLanguage = settingsPersistenceRef.current.current()?.language ?? 'system';
+        setLanguage(persistedLanguage);
+        if (modalSession === modalSessionRef.current) {
+          updateDraft({ language: persistedLanguage });
+          setError({ messageKey: 'settings.saveFailed', detail: errorDetail(reason) });
+        }
+      }
     }
   };
 
   const updateFontSize = async (fontSize: number) => {
-    const previousFontSize = loadedRef.current?.fontSize ?? DEFAULT_FONT_SIZE;
+    const modalSession = modalSessionRef.current;
+    const updateSeq = ++fontSizeUpdateSeqRef.current;
     setError(undefined);
     updateDraft({ fontSize });
-    const live = liveRef.current;
-    const next = mergeSettings(loadedRef.current, {
-      fontSize,
-      openProviders: live.openProviders,
-      focusPaneWidth: live.focusPaneWidth,
-      presentation: live.presentation,
-    });
     try {
-      await host.settings.set(next);
-      loadedRef.current = next;
+      const next = await persistSettingsPatch({ fontSize });
       onSaved(next);
+      if (modalSession === modalSessionRef.current) setError(undefined);
     } catch (reason) {
-      updateDraft({ fontSize: previousFontSize });
-      setError({ messageKey: 'settings.saveFailed', detail: errorDetail(reason) });
+      if (updateSeq === fontSizeUpdateSeqRef.current && modalSession === modalSessionRef.current) {
+        updateDraft({ fontSize: settingsPersistenceRef.current.current()?.fontSize ?? DEFAULT_FONT_SIZE });
+        setError({ messageKey: 'settings.saveFailed', detail: errorDetail(reason) });
+      }
     }
   };
 
   const save = async () => {
     if (!draft) return;
+    const modalSession = modalSessionRef.current;
+    const draftUpdateSeq = draftUpdateSeqRef.current;
+    languageUpdateSeqRef.current += 1;
+    fontSizeUpdateSeqRef.current += 1;
+    setSaving(true);
     setError(undefined);
-    const next = mergeSettings(loadedRef.current, {
-      ...draft,
-      openProviders,
-      focusPaneWidth,
-      presentation,
-    });
     try {
-      await host.settings.set(next);
-      loadedRef.current = next;
+      const next = await persistSettingsPatch({
+        ...draft,
+        openProviders,
+        focusPaneWidth,
+        presentation,
+      });
       onSaved(next);
-      setSaved(true);
-      closeTimerRef.current = window.setTimeout(onClose, 400);
+      if (modalSession === modalSessionRef.current && draftUpdateSeq === draftUpdateSeqRef.current) {
+        setSaved(true);
+        closeTimerRef.current = window.setTimeout(onClose, 400);
+      }
     } catch (reason) {
-      setError({ messageKey: 'settings.saveFailed', detail: errorDetail(reason) });
+      setLanguage(settingsPersistenceRef.current.current()?.language ?? 'system');
+      if (modalSession === modalSessionRef.current) {
+        setError({ messageKey: 'settings.saveFailed', detail: errorDetail(reason) });
+      }
+    } finally {
+      if (modalSession === modalSessionRef.current) setSaving(false);
     }
   };
 
@@ -424,7 +453,7 @@ export function SettingsModal({
               type="button"
               className="min-w-16 border border-sky-300 dark:border-sky-700 bg-sky-50 dark:bg-sky-950 px-3 py-1.5 text-sm text-sky-700 dark:text-sky-100 hover:bg-sky-100 dark:hover:bg-sky-900 disabled:cursor-not-allowed disabled:opacity-50"
               onClick={() => void save()}
-              disabled={!draft}
+              disabled={!draft || saving}
             >
               {saved ? t('settings.saved') : t('settings.save')}
             </button>

--- a/src/ui/SettingsModal.tsx
+++ b/src/ui/SettingsModal.tsx
@@ -6,7 +6,7 @@ import { AdapterAccessPanel } from './FocusPane';
 import { useI18n } from '../i18n/context';
 import { formatI18n } from '../i18n/t';
 import type { PresentationByProvider } from './presentation';
-import { type AppSettings, mergeSettings, normalizeSettings } from './settingsModel';
+import { type AppSettings, DEFAULT_FONT_SIZE, MIN_FONT_SIZE, mergeSettings, normalizeSettings } from './settingsModel';
 import { compareVersions, fetchLatestRelease } from './updateCheck';
 import { host } from '../host';
 import {
@@ -55,6 +55,7 @@ export function SettingsModal({
 }) {
   const { t, setLanguage } = useI18n();
   const [draft, setDraft] = useState<AppSettings | undefined>();
+  const [fontSizeText, setFontSizeText] = useState<string | undefined>();
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<SettingsError | undefined>();
   const [updateCheck, setUpdateCheck] = useState<UpdateCheckState>({ status: 'idle' });
@@ -71,6 +72,7 @@ export function SettingsModal({
     }
     let disposed = false;
     setDraft(undefined);
+    setFontSizeText(undefined);
     setSaved(false);
     setError(undefined);
     setUpdateCheck({ status: 'idle' });
@@ -138,6 +140,27 @@ export function SettingsModal({
     } catch (reason) {
       updateDraft({ language: previousLanguage });
       setLanguage(previousLanguage);
+      setError({ messageKey: 'settings.saveFailed', detail: errorDetail(reason) });
+    }
+  };
+
+  const updateFontSize = async (fontSize: number) => {
+    const previousFontSize = loadedRef.current?.fontSize ?? DEFAULT_FONT_SIZE;
+    setError(undefined);
+    updateDraft({ fontSize });
+    const live = liveRef.current;
+    const next = mergeSettings(loadedRef.current, {
+      fontSize,
+      openProviders: live.openProviders,
+      focusPaneWidth: live.focusPaneWidth,
+      presentation: live.presentation,
+    });
+    try {
+      await host.settings.set(next);
+      loadedRef.current = next;
+      onSaved(next);
+    } catch (reason) {
+      updateDraft({ fontSize: previousFontSize });
       setError({ messageKey: 'settings.saveFailed', detail: errorDetail(reason) });
     }
   };
@@ -229,6 +252,26 @@ export function SettingsModal({
                   <option value="dark">{t('settings.themeDark')}</option>
                   <option value="ai-sister">{t('settings.themeAiSister')}</option>
                 </select>
+              </label>
+            </section>
+
+            <section>
+              <label className="block text-xs text-zinc-600 dark:text-zinc-400">
+                <span className="mb-1 block font-medium text-zinc-700 dark:text-zinc-300">{t('settings.fontSize')}</span>
+                <input
+                  type="number"
+                  min={MIN_FONT_SIZE}
+                  step={1}
+                  value={fontSizeText ?? String(draft.fontSize)}
+                  onChange={(event) => {
+                    const text = event.target.value;
+                    setFontSizeText(text);
+                    const value = Number(text);
+                    if (Number.isFinite(value) && value >= MIN_FONT_SIZE) void updateFontSize(value);
+                  }}
+                  onBlur={() => setFontSizeText(undefined)}
+                  className="w-full border border-zinc-300 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900 px-2 py-1.5 text-sm text-zinc-900 dark:text-zinc-100 outline-none focus:border-sky-500 dark:focus:border-sky-600"
+                />
               </label>
             </section>
 
@@ -346,7 +389,7 @@ export function SettingsModal({
             {error.detail ? (
               <details className="mt-2">
                 <summary className="cursor-pointer font-medium">{t('settings.technicalDetails')}</summary>
-                <code className="mt-1 block break-words text-[11px] opacity-80">{error.detail}</code>
+                <code className="mt-1 block break-words text-[0.6875rem] opacity-80">{error.detail}</code>
               </details>
             ) : null}
           </div>
@@ -608,11 +651,11 @@ function EventLogRow({ event, now }: { event: EventLogEvent; now: number }) {
     <li className="px-3 py-2 text-xs">
       <div className="flex flex-wrap items-center gap-2 text-zinc-500 dark:text-zinc-500">
         <span>{formatRelativeTime(event.ts, now)}</span>
-        <span className="border border-zinc-300 dark:border-zinc-700 px-1.5 py-0.5 text-[11px] uppercase text-zinc-700 dark:text-zinc-300">{event.kind}</span>
+        <span className="border border-zinc-300 dark:border-zinc-700 px-1.5 py-0.5 text-[0.6875rem] uppercase text-zinc-700 dark:text-zinc-300">{event.kind}</span>
         {event.provider ? <span className="text-sky-700 dark:text-sky-300">{providerName(event.provider)}</span> : null}
       </div>
       <div className="mt-1 break-words text-zinc-800 dark:text-zinc-200">{event.summary}</div>
-      {event.detail ? <code className="mt-1 block break-words text-[11px] text-zinc-500 dark:text-zinc-500">{JSON.stringify(event.detail)}</code> : null}
+      {event.detail ? <code className="mt-1 block break-words text-[0.6875rem] text-zinc-500 dark:text-zinc-500">{JSON.stringify(event.detail)}</code> : null}
     </li>
   );
 }

--- a/src/ui/serialTaskQueue.ts
+++ b/src/ui/serialTaskQueue.ts
@@ -1,0 +1,14 @@
+export type SerialTaskQueue = <T>(task: () => Promise<T>) => Promise<T>;
+
+export function createSerialTaskQueue(): SerialTaskQueue {
+  let tail: Promise<void> = Promise.resolve();
+
+  return <T>(task: () => Promise<T>): Promise<T> => {
+    const result = tail.then(task, task);
+    tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+}

--- a/src/ui/settingsModel.ts
+++ b/src/ui/settingsModel.ts
@@ -70,7 +70,7 @@ function theme(value: unknown, fallback: AppSettings['theme']): AppSettings['the
 }
 
 export const DEFAULT_FONT_SIZE = 16;
-// ponytail: 下限 10px 防止 UI 縮到無法操作而救不回來；上限依需求不設
+// 下限 10px，避免 UI 縮到無法操作；依需求不限制上限。
 export const MIN_FONT_SIZE = 10;
 
 function fontSize(value: unknown): number {

--- a/src/ui/settingsModel.ts
+++ b/src/ui/settingsModel.ts
@@ -15,6 +15,7 @@ import { normalizeLanguageSetting, type LanguageSetting } from '../i18n/resolve'
 export interface AppSettings {
   language: LanguageSetting;
   theme: 'light' | 'dark' | 'ai-sister';
+  fontSize: number;
   layoutMode: 'focus';
   focusPaneWidth: number;
   columnWidths: ColumnWidths;
@@ -35,6 +36,7 @@ export function defaultSettings(): AppSettings {
   return {
     language: 'system',
     theme: 'light',
+    fontSize: DEFAULT_FONT_SIZE,
     layoutMode: 'focus',
     focusPaneWidth: DEFAULT_FOCUS_PANE_WIDTH,
     columnWidths: { ...DEFAULT_COLUMN_WIDTHS },
@@ -65,6 +67,14 @@ function snapshotRedactionTier(value: unknown, fallback: SnapshotRedactionTier):
 
 function theme(value: unknown, fallback: AppSettings['theme']): AppSettings['theme'] {
   return value === 'light' || value === 'dark' || value === 'ai-sister' ? value : fallback;
+}
+
+export const DEFAULT_FONT_SIZE = 16;
+// ponytail: 下限 10px 防止 UI 縮到無法操作而救不回來；上限依需求不設
+export const MIN_FONT_SIZE = 10;
+
+function fontSize(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= MIN_FONT_SIZE ? value : DEFAULT_FONT_SIZE;
 }
 
 function columnWidths(value: unknown, fallback: ColumnWidths): ColumnWidths {
@@ -99,6 +109,7 @@ export function normalizeSettings(value: unknown): AppSettings {
   return {
     language: normalizeLanguageSetting(input.language),
     theme: theme(input.theme, defaults.theme),
+    fontSize: fontSize(input.fontSize),
     layoutMode: 'focus',
     focusPaneWidth: focusPaneWidth(input.focusPaneWidth, input.columnWidths, defaults.focusPaneWidth),
     columnWidths: normalizedColumnWidths,

--- a/src/ui/settingsPersistence.ts
+++ b/src/ui/settingsPersistence.ts
@@ -1,0 +1,38 @@
+import { createSerialTaskQueue } from './serialTaskQueue';
+import { type AppSettings, mergeSettings, normalizeSettings } from './settingsModel';
+
+interface SettingsStore {
+  get: () => Promise<unknown>;
+  set: (settings: unknown) => Promise<void>;
+}
+
+export type SettingsPatch = Partial<AppSettings> | (() => Partial<AppSettings>);
+
+export function createSettingsPersistence(store: SettingsStore) {
+  const enqueue = createSerialTaskQueue();
+  let current: AppSettings | undefined;
+
+  return {
+    load: (): Promise<AppSettings> =>
+      enqueue(async () => {
+        const loaded = normalizeSettings(await store.get());
+        current = loaded;
+        return loaded;
+      }),
+
+    update: (patch: SettingsPatch): Promise<AppSettings> =>
+      enqueue(async () => {
+        const resolvedPatch = typeof patch === 'function' ? patch() : patch;
+        const next = mergeSettings(current, resolvedPatch);
+        await store.set(next);
+        current = next;
+        return next;
+      }),
+
+    replaceCurrent: (settings: AppSettings): void => {
+      current = settings;
+    },
+
+    current: (): AppSettings | undefined => current,
+  };
+}

--- a/src/ui/trailingDebounce.ts
+++ b/src/ui/trailingDebounce.ts
@@ -1,0 +1,61 @@
+export interface TrailingDebounce<T> {
+  schedule: (value: T) => void;
+  flush: () => Promise<void>;
+  cancel: () => void;
+}
+
+export function createTrailingDebounce<T>(
+  callback: (value: T) => void | Promise<void>,
+  delayMs: number,
+): TrailingDebounce<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let pending: T | undefined;
+  let active: Promise<void> | undefined;
+
+  const clearTimer = () => {
+    if (timer === undefined) return;
+    clearTimeout(timer);
+    timer = undefined;
+  };
+
+  const runPending = (): Promise<void> => {
+    if (pending === undefined) return active ?? Promise.resolve();
+    const value = pending;
+    pending = undefined;
+    let result: Promise<void>;
+    try {
+      result = Promise.resolve(callback(value));
+    } catch (reason) {
+      result = Promise.reject(reason);
+    }
+    active = result;
+    void result.then(
+      () => {
+        if (active === result) active = undefined;
+      },
+      () => {
+        if (active === result) active = undefined;
+      },
+    );
+    return result;
+  };
+
+  return {
+    schedule: (value) => {
+      pending = value;
+      clearTimer();
+      timer = setTimeout(() => {
+        timer = undefined;
+        void runPending().catch(() => undefined);
+      }, delayMs);
+    },
+    flush: () => {
+      clearTimer();
+      return runPending();
+    },
+    cancel: () => {
+      clearTimer();
+      pending = undefined;
+    },
+  };
+}


### PR DESCRIPTION
## 摘要

### fix: 真實頁面 webview 錯位（擋住工具列、無法操作）
- 根因:Windows「文字大小」縮放會成為 WebView2 的頁面 ZoomFactor,前端 `getBoundingClientRect()` 的 CSS px 與 Tauri Logical px 差了 zoom 倍,provider webview 被放到偏左上、蓋住「文字檢視」返回鈕。
- 修正:前端 `toBounds` 乘上 `devicePixelRatio` 轉為實體像素,Rust 端 `set_webview_bounds` / `provider_open` 改用 `Physical` 座標(CSS px × dpr = 實體像素,任何 DPI/文字縮放組合皆成立)。
- 另修:allowlisted 的 `window.open`(OAuth/SSO)彈窗改用 `NewWindowResponse::Create` 自建有標題列、可拖曳的視窗;平台預設 popup 無邊框拖不動。`window_features()` 保留 opener 環境,OAuth 回跳不受影響。
- Popup 初始標題僅顯示 host，避免 OAuth path/query 出現在 OS 標題列；載入後仍由 document title 接手。
- WebView bounds 在套用前統一驗證 finite/range/positive-size 並取整，避免 NaN、Infinity 或溢位被靜默 cast。

### feat: 字體大小設定
- 設定頁新增字體大小(套用至 `documentElement`),硬編碼 px 文字改為 rem,四語系 i18n。
- 設定讀寫改為可恢復的序列佇列，確保快速連續調整時最後輸入一定勝出，且語言、字體與 Save 不會因非同步完成順序而互相覆蓋。
- 字體持久化使用 250ms trailing debounce，減少快速輸入造成的磁碟寫入；Save 會取消尚未啟動的 debounce，關閉視窗則等待最新寫入完成。
- 補上 close/reopen session guard、Save pending 狀態與回歸測試，避免舊請求污染重新開啟的設定視窗。

### docs
- 新增 `docs/RUN-AND-UPDATE.md` 執行與更新指南。

## 驗證
- 實機驗證:文字縮放 110% 下 webview 對齊置中區、工具列可見可點。
- `cargo fmt --check` 與 Rust 全套 50 tests 通過。
- `pnpm verify` 通過：typecheck、lint、45 個測試檔 / 338 個測試、agent contract 與 adapter schema 全數通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
