### PR TITLE
fix: keep centered webview hidden while an overlay is open

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -873,6 +873,9 @@ export default function App() {
 
   const driveCenteredProviderToStage = useCallback(async (provider: AIProvider) => {
     if (centerSurfaceRef.current !== 'native') return;
+    // overlay(設定、preflight 等)開啟時 guard 已 hide webview；此處若照常把
+    // bounds 推回舞台，syncBounds 的 park→show 會讓 webview 重新蓋在 overlay 上。
+    if (overlayGuardOpenRef.current) return;
     await driveCenteredProviderToStageCommand({
       provider,
       presentation: presentationRef.current[provider],
@@ -1280,6 +1283,12 @@ export default function App() {
   useEffect(() => {
     syncAllBounds();
   }, [focusPaneWidth, presentation, syncAllBounds]);
+
+  // overlay 關閉後立即把置中的 webview 推回舞台，不等 2.5 秒的定時同步。
+  useEffect(() => {
+    if (overlayGuardOpen) return;
+    if (centeredProvider && centerSurfaceRef.current === 'native') void driveCenteredProviderToStage(centeredProvider);
+  }, [overlayGuardOpen, centeredProvider, driveCenteredProviderToStage]);
 
   const executeSend = async (trimmed: string) => {
     if (!trimmed) return;


### PR DESCRIPTION
## Problem

With the real-page (native) center view active, opening Settings makes the provider webview float above the settings panel (native webviews always render on top of the HTML UI).

## Cause

The overlay guard correctly hides the centered webview when an overlay opens, but the 2.5s bounds-sync loop (and the center-stage ResizeObserver) undid it:

1. `syncBounds` takes the park path while an overlay is open, and `park()` calls `provider_show` after moving the webview off-screen.
2. `driveCenteredProviderToStage` did not check the overlay-guard state and pushed the webview bounds straight back onto the center stage.

Net effect: hidden webview → re-shown off-screen → moved back on stage, covering the settings panel.

## Fix (src/App.tsx only)

- `driveCenteredProviderToStage` bails out while the overlay guard is open.
- A new effect re-drives the centered webview to the stage as soon as the overlay closes, so the stage is not blank for up to 2.5s waiting for the next sync tick.

This also covers the other overlays sharing the same guard (preflight, step-timeout dialog, report preview, process-trace detail).

## Verification

- `npm run typecheck` passes
- `npx vitest run`: 46 files / 351 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)