### PR TITLE
fix: preserve line breaks and convert tables when extracting responses

### DIFF
--- a/injected/engine.ts
+++ b/injected/engine.ts
@@ -87,6 +87,54 @@ class InputInjectionError extends Error {
   }
 }
 
+// textContent flattens block elements into one run of text; walk the DOM so
+// paragraphs/list items keep their line breaks and tables become markdown.
+const BLOCK_TAGS = new Set([
+  'ADDRESS', 'ARTICLE', 'ASIDE', 'BLOCKQUOTE', 'DD', 'DETAILS', 'DIV', 'DL', 'DT', 'FIGCAPTION', 'FIGURE',
+  'FOOTER', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'HEADER', 'HR', 'LI', 'MAIN', 'NAV', 'OL', 'P', 'SECTION', 'UL',
+]);
+
+export function serializeResponseText(root: Element): string {
+  return serializeNode(root)
+    .split('\n')
+    .map((line) => (line.trim() ? line : ''))
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function serializeNode(node: Node): string {
+  if (node.nodeType === 3) return node.textContent ?? '';
+  const el = node as Element;
+  if (node.nodeType !== 1 && typeof el.tagName !== 'string') return '';
+  // Test doubles (and exotic hosts) have textContent but no childNodes.
+  if (!el.childNodes) return el.textContent ?? '';
+  const tag = el.tagName.toUpperCase();
+  if (tag === 'BR') return '\n';
+  if (tag === 'PRE') return `\n${el.textContent ?? ''}\n`;
+  if (tag === 'TABLE') {
+    const markdown = tableToMarkdown(el);
+    if (markdown) return `\n${markdown}\n`;
+  }
+  let out = '';
+  for (const child of el.childNodes) out += serializeNode(child);
+  return BLOCK_TAGS.has(tag) ? `\n${out}\n` : out;
+}
+
+function tableToMarkdown(table: Element): string {
+  const rows: string[][] = [];
+  for (const tr of table.querySelectorAll('tr')) {
+    const cells = Array.from(tr.querySelectorAll('th, td')).map((cell) =>
+      (cell.textContent ?? '').replace(/\s+/g, ' ').trim().replace(/\|/g, '\\|'),
+    );
+    if (cells.length > 0) rows.push(cells);
+  }
+  if (rows.length === 0) return '';
+  const line = (cells: string[]) => `| ${cells.join(' | ')} |`;
+  const [head, ...body] = rows;
+  return [line(head), line(head.map(() => '---')), ...body.map(line)].join('\n');
+}
+
 (function engine() {
   if (typeof window === 'undefined') return;
   if (window.self !== window.top) return;
@@ -494,7 +542,7 @@ class InputInjectionError extends Error {
   }
 
   function extractResponseText(response: Element): string | null {
-    const text = response.textContent?.trim() ?? '';
+    const text = serializeResponseText(response);
     if (text) return text;
     const asset = response.querySelector('img, canvas, video');
     if (!asset) return null;

--- a/src/__tests__/responseSerialize.test.ts
+++ b/src/__tests__/responseSerialize.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { serializeResponseText } from '../../injected/engine';
+
+interface FakeNode {
+  nodeType: number;
+  tagName?: string;
+  childNodes?: FakeNode[];
+  readonly textContent: string;
+  querySelectorAll?: (selector: string) => FakeNode[];
+}
+
+function text(content: string): FakeNode {
+  return { nodeType: 3, textContent: content };
+}
+
+function el(tag: string, children: FakeNode[] = []): FakeNode {
+  const node: FakeNode = {
+    nodeType: 1,
+    tagName: tag.toUpperCase(),
+    childNodes: children,
+    get textContent() {
+      return children.map((child) => child.textContent).join('');
+    },
+    querySelectorAll(selector: string) {
+      const tags = selector.split(',').map((part) => part.trim().toUpperCase());
+      const found: FakeNode[] = [];
+      const walk = (parent: FakeNode) => {
+        for (const child of parent.childNodes ?? []) {
+          if (child.tagName && tags.includes(child.tagName)) found.push(child);
+          walk(child);
+        }
+      };
+      walk(node);
+      return found;
+    },
+  };
+  return node;
+}
+
+const serialize = (node: FakeNode) => serializeResponseText(node as unknown as Element);
+
+describe('serializeResponseText', () => {
+  it('keeps paragraph breaks instead of flattening blocks', () => {
+    const root = el('div', [el('p', [text('第一段')]), el('p', [text('第二段')])]);
+    expect(serialize(root)).toBe('第一段\n\n第二段');
+  });
+
+  it('puts list items on their own lines', () => {
+    const root = el('ul', [el('li', [text('one')]), el('li', [text('two')])]);
+    expect(serialize(root)).toBe('one\n\ntwo');
+  });
+
+  it('turns <br> into a line break', () => {
+    const root = el('p', [text('a'), el('br'), text('b')]);
+    expect(serialize(root)).toBe('a\nb');
+  });
+
+  it('converts tables to markdown and escapes pipes', () => {
+    const root = el('table', [
+      el('tr', [el('th', [text('名稱')]), el('th', [text('值')])]),
+      el('tr', [el('td', [text('a|b')]), el('td', [text('  多  空白 ')])]),
+    ]);
+    expect(serialize(root)).toBe('| 名稱 | 值 |\n| --- | --- |\n| a\\|b | 多 空白 |');
+  });
+
+  it('preserves code indentation inside <pre>', () => {
+    const root = el('div', [el('pre', [text('if x:\n    y()')])]);
+    expect(serialize(root)).toBe('if x:\n    y()');
+  });
+
+  it('falls back to textContent when childNodes is unavailable', () => {
+    const bare = { nodeType: 1, tagName: 'DIV', textContent: 'native answer' };
+    expect(serializeResponseText(bare as unknown as Element)).toBe('native answer');
+  });
+});


### PR DESCRIPTION
## Problem

ChatGPT and Gemini replies rendered in the app lose all line breaks — multi-paragraph answers collapse into one unbroken run of text, and tables come out as garbled inline text.

## Cause

`extractResponseText` in `injected/engine.ts` reads the response element with `textContent`, which concatenates text nodes with no regard for block structure: `<p>`, `<li>`, table rows, etc. contribute no newlines.

## Fix

Replace the `textContent` read with a small DOM serializer shared by all providers:

- Block elements (`p`, `li`, headings, `div`, …) get surrounding newlines; runs of 3+ newlines collapse to a blank line.
- `<br>` becomes `\n`; `<pre>` content is kept verbatim so code indentation survives.
- `<table>` is converted to a markdown pipe table (header separator row, `|` escaped, cell whitespace collapsed).
- Nodes without `childNodes` fall back to `textContent`, so the existing engine test doubles are unaffected.

## Verification

- New unit tests in `src/__tests__/responseSerialize.test.ts` (paragraph breaks, list items, `<br>`, table→markdown with pipe escaping, `<pre>` indentation, fallback).
- `npm run typecheck`, `eslint .`, `npm run build:injected`, and the full `vitest` suite (357 tests / 47 files) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)