### PR TITLE
fix: stop transcript autoscroll from shifting the whole app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1949,7 +1949,9 @@ export function ChatArea({
   const bottomRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    // block: 'nearest' 只捲 transcript 容器；預設 'start' 會連外層 overflow-hidden 的
+    // app shell 一起捲，把頂部 logo 與匯出鈕推出畫面。
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   }, [messages]);
 
   if (messages.length === 0) {


### PR DESCRIPTION
## Problem

During a conversation, the top-left brand icon and the top-right Export .md / Settings buttons scroll out of view. The whole app layout shifts upward and never recovers on its own.

## Cause

`ChatArea` calls `bottomRef.current?.scrollIntoView({ behavior: 'smooth' })` on every message update. `block` defaults to `'start'`, which scrolls **every** scrollable ancestor — including the `overflow-hidden` app shell (`overflow: hidden` boxes are still programmatically scrollable) — to bring the transcript's bottom sentinel to the top of each scrollport. That pushes the entire app content up, hiding the header areas.

## Fix

One line: pass `block: 'nearest'` so only the transcript's own `overflow-auto` container scrolls; ancestors are left untouched.

## Verification

- Reproduced the original bug in `pnpm tauri dev` (free-dispatch mode, 4 providers): after sending a message the whole page scrolled up, hiding the brand icon and Export .md button.
- With the fix, re-ran the same flow: header stays in place during and after the workflow, and the transcript still auto-scrolls to the newest message inside its own container.
- `npm run typecheck` and `npx vitest run` (351 tests) pass. No test added: jsdom does not implement scrolling behavior, so a test could only assert the option literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)