### PR TITLE
test: pin direct-row tables and bare <pre> serializer edge cases

### DIFF
--- a/src/__tests__/responseSerializer.test.ts
+++ b/src/__tests__/responseSerializer.test.ts
@@ -66,12 +66,27 @@ describe('serializeResponseText', () => {
     expect(serialized.split('\n')).toHaveLength(3);
   });
 
+  it('converts tables whose rows are direct children of <table>', () => {
+    const root = element('table', [
+      element('tr', [element('th', [text('Name')]), element('th', [text('Value')])]),
+      element('tr', [element('td', [text('a')]), element('td', [text('b')])]),
+    ]);
+
+    expect(serialize(root)).toBe('| Name | Value |\n| --- | --- |\n| a | b |');
+  });
+
   it('uses fenced code while preserving indentation on the very first preformatted line', () => {
     const root = element('pre', [
       element('code', [text('    firstLine()\n  secondLine()')], { class: 'language-ts' }),
     ]);
 
     expect(serialize(root)).toBe('```ts\n    firstLine()\n  secondLine()\n```');
+  });
+
+  it('fences bare <pre> blocks that have no inner <code>', () => {
+    const root = element('pre', [text('if x:\n    y()')]);
+
+    expect(serialize(root)).toBe('```\nif x:\n    y()\n```');
   });
 
   it('ignores non-elements safely and falls back when childNodes is unavailable', () => {


### PR DESCRIPTION
## Problem

Two serializer edge cases discussed in #13 (from the superseded #10) are handled by the code but not pinned by any assertion, so a future refactor could silently regress them.

## Cause

- `tableRows()` supports `<tr>` rows that are direct children of `<table>` (no `thead`/`tbody`), but every existing table test wraps rows in a section tag.
- `protectCodeBlock()` falls back to the `<pre>` element itself when there is no inner `<code>`, but the only fenced-code test uses `pre > code`.

## Fix

Add two tests to `src/__tests__/responseSerializer.test.ts` — one for a direct-row table, one for a bare `<pre>` block. Test-only change; no production code touched.

## Verification

- `npm run typecheck`
- `npx vitest run` — 49 files, 367 tests passed (365 existing + 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
