### PR TITLE
fix: harden ChatGPT editor injection

### DIFF
--- a/adapters/chatgpt.json
+++ b/adapters/chatgpt.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema.json",
   "schemaVersion": 1,
-  "adapterVersion": 4,
+  "adapterVersion": 5,
   "provider": "chatgpt",
   "displayName": "ChatGPT",
   "urls": {
@@ -17,7 +17,7 @@
   "loggedOutDetectors": [],
   "thinkingDetectors": ["[data-testid=\"stop-button\"]", "button[aria-label=\"Stop generating\"]", "button[aria-label=\"Stop streaming\"]", "button[aria-label=\"Stop\"]"],
   "stopButtonSelectors": ["[data-testid=\"stop-button\"]", "button[aria-label=\"Stop generating\"]", "button[aria-label=\"Stop streaming\"]", "button[aria-label=\"Stop\"]"],
-  "inputStrategy": "default",
+  "inputStrategy": "prosemirror-paste",
   "sendStrategy": "click",
   "timing": { "doneDelayMs": 3000, "chunkDebounceMs": 800, "statusIntervalMs": 10000, "backupPollMs": 3000 }
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -334,7 +334,7 @@ Source of truth: `docs/study/multi-ai-chat.md` §2 + §7 (line-referenced to the
 | loginDetectors | `#prompt-textarea` · `[data-testid="send-button"]` | `.ProseMirror[contenteditable="true"]` · `[contenteditable="true"].ProseMirror` | `.ql-editor[contenteditable="true"]` · `rich-textarea [contenteditable="true"]` · `div[contenteditable="true"][aria-label="Enter a prompt here"]` | `[data-testid="chat-input"] .ProseMirror[contenteditable="true"]` · `.ProseMirror[contenteditable="true"]` · `[data-testid="chat-submit"]` |
 | thinkingDetectors | `[data-testid="stop-button"]` · `button[aria-label="Stop generating"]` · `button[aria-label="Stop streaming"]` · `button[aria-label="Stop"]` | `[data-is-streaming="true"]` · `button[aria-label="Stop Response"]` · `button[aria-label="Stop response"]` · `button[aria-label="Stop"]` | `.loading-indicator` · `.thinking-indicator` · `mat-progress-bar` · stop buttons (en + zh-TW per original gemini.ts:53-65) · `.response-streaming` · `[data-test-id="response-loading"]` | stop buttons (grok.ts:38-43) · `[data-streaming="true"]` · `{selector: ".thinking-container", textIncludes: "Thinking", textExcludes: "Thought for"}` |
 | stopButtonSelectors | the 4 stop-button selectors above | the 3 `button[aria-label*=Stop]` selectors | stop buttons subset (en + zh-TW) | stop buttons subset |
-| inputStrategy | `default` | `prosemirror-paste` | `quill-angular` | `prosemirror-paste` |
+| inputStrategy | `prosemirror-paste` | `prosemirror-paste` | `quill-angular` | `prosemirror-paste` |
 | doneDelayMs | 3000 | 5000 | 4000 | **8000** — do not reduce: roundtable round 5 carries 4 rounds × 4 speakers of history; Grok finalizes prematurely with shorter delays (original grok.ts:92-94) |
 | chunkDebounceMs | 800 | 500 | 600 | 600 |
 

--- a/scripts/check-adapters.mjs
+++ b/scripts/check-adapters.mjs
@@ -11,14 +11,14 @@ const validate = ajv.compile(schema);
 
 const expected = {
   chatgpt: {
-    adapterVersion: 4,
+    adapterVersion: 5,
     urls: {
       app: 'https://chatgpt.com',
       login: 'https://chatgpt.com/auth/login',
       match: ['chatgpt.com/*', 'chat.openai.com/*'],
       ssoMatch: ['auth.openai.com/*', 'auth0.openai.com/*', 'gsi.google.com/*', 'https://www.google.com/accounts', 'accounts.google.com.tw/*'],
     },
-    inputStrategy: 'default',
+    inputStrategy: 'prosemirror-paste',
     doneDelayMs: 3000,
     chunkDebounceMs: 800,
     inputSelectors: ['#prompt-textarea', '[id="prompt-textarea"]', 'div[contenteditable="true"][data-placeholder]'],

--- a/src/__tests__/engine-input.test.ts
+++ b/src/__tests__/engine-input.test.ts
@@ -170,6 +170,23 @@ describe('injected engine input hardening', () => {
     expect(env.input.textContent).toBe('fallback prompt');
   });
 
+  it('replaces mismatched stale editor text before sending with the ProseMirror strategy', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'contenteditable' });
+    env.input.setVisibleText('stale editor draft');
+    const handler = await installEngine(env);
+    dispatchAdapter(handler, { provider: 'chatgpt', inputStrategy: 'prosemirror-paste' });
+
+    send(handler, 'fresh ChatGPT prompt', 'chatgpt');
+    await flushMicrotasks();
+
+    expect(env.input.textContent).toBe('fresh ChatGPT prompt');
+    expect(errorDone(env)).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(PRE_SEND_DELAY_MS);
+    expect(env.sendButton?.clickCount).toBe(1);
+  });
+
   it('falls back from a missing send button to one Enter target on the shortened budget', async () => {
     vi.useFakeTimers();
     const env = createEnv({ inputKind: 'textarea', sendButton: null });
@@ -521,8 +538,8 @@ function dispatchAdapter(handler: (message: BridgeMessage) => void, overrides: P
   handler({ v: 1, action: 'ADAPTER_UPDATE', payload: adapter } as BridgeMessage);
 }
 
-function send(handler: (message: BridgeMessage) => void, text: string) {
-  handler({ v: 1, action: 'SEND_MESSAGE', provider: 'grok', payload: { text } });
+function send(handler: (message: BridgeMessage) => void, text: string, provider: AIProvider = 'grok') {
+  handler({ v: 1, action: 'SEND_MESSAGE', provider, payload: { text } });
 }
 
 function fill(handler: (message: BridgeMessage) => void, text: string) {

--- a/src/__tests__/m0.test.ts
+++ b/src/__tests__/m0.test.ts
@@ -42,7 +42,8 @@ describe('M0 shared constants and adapter seeds', () => {
   });
 
   it('matches SPEC section 5.1 strategy and timing seed values', () => {
-    expect(chatgpt.inputStrategy).toBe('default');
+    expect(chatgpt.adapterVersion).toBe(5);
+    expect(chatgpt.inputStrategy).toBe('prosemirror-paste');
     expect(chatgpt.timing.doneDelayMs).toBe(3000);
     expect(chatgpt.timing.chunkDebounceMs).toBe(800);
 


### PR DESCRIPTION
## Summary

- bump the ChatGPT adapter to v5 and route its contenteditable composer through the existing recoverable ProseMirror injection strategy
- replace stale or mismatched editor text before attempting to send
- add a ChatGPT regression test for the reported non-empty mismatch path
- update the adapter contract checks and specification

The released desktop app already contains this named input strategy. Once merged, the existing adapter hot-update path can deliver v5 without rebuilding or publishing a new installer.

## Validation

- pnpm verify (366 frontend tests and 20 agent tests)
- cargo test --manifest-path src-tauri/Cargo.toml (52 tests)
- adapter schema and seed contract checks