### PR TITLE
docs: prepare v1.4.0 release

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -10,6 +10,17 @@ Stelle eine Frage und lasse deine angemeldeten Web-Sitzungen von **ChatGPT, Clau
 
 > **Projektstatus:** Die Funktionsentwicklung ist abgeschlossen. Das letzte optionale Gedenk-Theme mit allen vier AI-Sister-Figuren ist enthalten; danach werden nur Anbieterkompatibilität, Sicherheit und Build-Probleme gepflegt. Die vorhandenen Snapshot-/Replay-Funktionen bleiben unverändert und werden nicht erweitert.
 
+## Neuerungen in v1.4.0
+
+- **Wiederhergestellte Gespräche werden wirklich fortgesetzt.** Die erste Nachfrage nach dem Öffnen oder Wechseln einer Sitzung erhält einmalig einen begrenzten Verlauf nur aus dieser Sitzung; neue Gespräche bleiben getrennt.
+- **Kein Überschreiben alter Nachrichten.** Stabile Response-Identitäten verhindern, dass neue Antworten serieller Workflows wiederhergestellte Bubbles ersetzen.
+- **Antwortformat mit höherer Treue.** Provider-DOM wird in sicheres semantisches Markdown mit Absätzen, verschachtelten Listen, Links, Codeblöcken und GFM-Tabellen umgewandelt.
+- **Ruhigeres Scrollen.** Nur das Transkript folgt neuen Ausgaben. Wer nach oben scrollt, behält seine Position, bis eine neue Nachricht oder Sitzung die Nachführung wieder aktiviert.
+- **Sicherere lokale Speicherung.** Alte Sitzungen werden nur bei erkannten Speicherquota-Fehlern entfernt; die Seitenleiste entspricht den tatsächlich gespeicherten Daten.
+- **Zuverlässigere ChatGPT-Eingabe.** Adapter v5 repariert veraltete oder abweichende Rich-Editor-Entwürfe vor dem Senden und wird auch über den vorhandenen Adapter-Hot-Update-Kanal verteilt.
+
+Validierung und bekannte Plattformgrenzen stehen in den zweisprachigen [`v1.4.0 Release Notes`](./docs/RELEASE_NOTES_v1.4.0.md).
+
 ## Edition wählen
 
 | Edition | Geeignet für | Ausführung |
@@ -22,8 +33,8 @@ Stelle eine Frage und lasse deine angemeldeten Web-Sitzungen von **ChatGPT, Clau
 - Zuverlässige Automatisierung im Hintergrund; abgelehnte Sendungen werden erneut versucht oder klar als Fehler gemeldet.
 - Workflow-Steuerung links über dem weniger wichtigen WebView; mehr Platz für Transkript und Eingabe rechts.
 - Freie Verteilung, Debatte, Beratung, Coding und fünf Runden Wahrheitssuche.
-- Bis zu 30 lokale Sitzungen plus **Neuer Chat**.
-- Sicher gerendertes Markdown, Abschluss von reinen Bildantworten, Snapshots, Replay und 2.000 Diagnoseereignisse.
+- Bis zu 30 lokale Sitzungen plus **Neuer Chat**; wiederhergestellte Nachfragen erhalten begrenzten Kontext nur aus derselben Sitzung.
+- Sicher gerendertes Markdown mit Überschriften, verschachtelten Listen, Links, Codeblöcken und scrollbaren Tabellen; außerdem Abschluss reiner Bildantworten, Snapshots, Replay und 2.000 Diagnoseereignisse.
 - English, 繁體中文, 日本語 und Deutsch.
 - Die Antwortsprache ist von der Oberflächensprache getrennt. Automatisch gelten zuerst ausdrückliche Vorgaben, dann Frage und Gespräch; die Oberfläche ist nur der Rückfall. Eine feste Antwortsprache ist ebenfalls wählbar.
 - Die optionale **AI-Sister Gedenkausgabe** zeigt alle vier Figuren in Anbieterkarten, Sprecherstatus, Prozesszeilen und App-Oberfläche; Drittanbieter-Seiten bleiben unverändert.
@@ -147,5 +158,11 @@ Vertrag: [`docs/SPEC.md`](./docs/SPEC.md) · Architektur: [`docs/ARCHITECTURE.md
 Keine API-Schlüssel, kein Projektkonto, keine Telemetrie und kein eigener Gesprächsserver. Prompts gehen direkt an die ausgewählten Anbieter-Seiten; Cookies und Profile bleiben lokal. Adapter-Updates sind optionale reine JSON-Daten, werden gegen das Schema geprüft und können die mitgelieferten URL-Grenzen nicht erweitern. Debug-Bundles, Exporte und Freigaben werden nur nach einer ausdrücklichen Benutzeraktion erstellt.
 
 Schwachstellen bitte gemäß [`SECURITY.md`](./SECURITY.md) privat melden. Regressionen der Provider-Automatisierung können nach Prüfung der App-Diagnose über das GitHub-Formular **Adapter broken** gemeldet werden.
+
+### Mitwirkende und Danksagung
+
+Besonderer Dank gilt [Dave Tseng (`@DaveTseng2019`)](https://github.com/DaveTseng2019) für die Overlay-Zuverlässigkeitskorrektur in `v1.3.1`, die sorgfältigen Reproduktionen und ursprünglichen Lösungsansätze in [#10](https://github.com/teddashh/multi-ai-chat-desktop/pull/10), [#11](https://github.com/teddashh/multi-ai-chat-desktop/pull/11) und [#12](https://github.com/teddashh/multi-ai-chat-desktop/pull/12) sowie die in [#14](https://github.com/teddashh/multi-ai-chat-desktop/pull/14) zusammengeführten Serializer-Regressionstests.
+
+Danke auch an die Windows- und macOS-Nutzer, die reproduzierbare Berichte und bereinigte Debug-Logs geteilt haben. Diese Hinweise verbesserten unmittelbar die Erststart-Pakete, Provider-Automatisierung, Sitzungsfortsetzung und Release-Prüfung.
 
 Sponsored by [AI-Sister.com](https://ai-sister.com). Erstellt von Ted Huang ([TED@TED-H.com](mailto:TED@TED-H.com), [ted-h.com](https://ted-h.com)). MIT License.

--- a/README.ja.md
+++ b/README.ja.md
@@ -10,6 +10,17 @@
 
 > **プロジェクト状況：** 機能開発は完了し、最後のオプションとして4人のAI-Sister記念Themeを追加しました。今後はprovider互換性、セキュリティ、build障害のみを保守します。既存のsnapshot／replayは現状のまま残し、拡張しません。
 
+## v1.4.0 の更新点
+
+- **復元した会話を本当に継続。** Sessionを開き直す、または切り替えた後の最初の追質問では、そのsessionだけの制限付き履歴を一度だけ渡し、新しい会話とは混在させません。
+- **履歴の上書きを防止。** 安定したresponse identityにより、新しいserial workflowの回答が復元済みbubbleを置き換えなくなりました。
+- **回答形式を忠実に保持。** Provider DOMを安全なsemantic Markdownへ変換し、段落、ネストしたlist、link、fenced code、GFM tableを保持します。
+- **落ち着いた自動スクロール。** Transcriptだけを追従し、過去を読むため上へスクロールした場合は、新しいmessageまたはsessionまで追従を停止します。
+- **安全なローカル保存。** 確認済みのstorage quotaエラーの場合だけ古いsessionを削除し、sidebarを実際に保存された内容と一致させます。
+- **ChatGPT入力の信頼性向上。** Adapter v5が送信前に古い、または不一致のrich-editor draftを修復し、既存のadapter hot-updateからも配信されます。
+
+検証内容と既知のplatform制限は、日英併記の [`v1.4.0 release notes`](./docs/RELEASE_NOTES_v1.4.0.md) を参照してください。
+
 ## エディション
 
 | エディション | 用途 | 実行方法 |
@@ -22,8 +33,8 @@
 - 非表示のプロバイダーにも安定して送信し、失敗時は再試行または明確なエラーを表示。
 - workflow コントロールを左側 WebView の上へ移動し、右側の会話と入力欄を広く確保。
 - 自由送信、四者討論、多角相談、Coding、5ラウンド円卓討論。
-- 最大30件のローカル会話履歴と「新しい会話」。
-- 安全な Markdown、画像のみの回答完了判定、snapshot／replay、2,000件の診断ログ。
+- 最大30件のローカル会話履歴と「新しい会話」。復元後の追質問には同一sessionだけの制限付きcontextを渡します。
+- 見出し、ネストしたlist、link、fenced code、scroll可能なtableを安全に表示するMarkdown、画像のみの回答完了判定、snapshot／replay、2,000件の診断ログ。
 - English、繁體中文、日本語、Deutsch。
 - 応答言語はインターフェース言語から独立。自動では、明示的な指定、質問、会話の言語を優先し、インターフェース言語は最後のフォールバックとして使用。固定の応答言語も選択可能。
 - 4人のキャラクターをproviderカード、発言状態、process row、app shellに表示する唯一のオプションTheme「AI-Sister 記念版」。第三者ページ自体は変更しません。
@@ -147,5 +158,11 @@ pnpm tauri dev
 APIキー、独自アカウント、telemetry、会話backendはありません。promptは選択したproviderページへ直接送信され、cookieとprofileはローカルに残ります。adapter更新は任意のデータ専用JSONで、schema検証され、同梱URL範囲を拡張できません。debug bundle、export、shareは利用者が明示的に実行した場合だけ動作します。
 
 脆弱性は [`SECURITY.md`](./SECURITY.md) に従って非公開で報告してください。Provider自動化の不具合は、アプリ内診断を確認してからGitHubの **Adapter broken** フォームで報告できます。
+
+### コントリビューターと謝辞
+
+[Dave Tseng（`@DaveTseng2019`）](https://github.com/DaveTseng2019) に特別な感謝を表します。`v1.3.1` のoverlay信頼性修正、[#10](https://github.com/teddashh/multi-ai-chat-desktop/pull/10)・[#11](https://github.com/teddashh/multi-ai-chat-desktop/pull/11)・[#12](https://github.com/teddashh/multi-ai-chat-desktop/pull/12)での詳細な再現と初期案、そして [#14](https://github.com/teddashh/multi-ai-chat-desktop/pull/14) でmergeされたserializer regression testに貢献しました。
+
+再現可能な報告とsanitized debug logを共有したWindows／macOSユーザーにも感謝します。これらの報告が初回起動package、provider自動化、session継続、release検証を直接改善しました。
 
 Sponsored by [AI-Sister.com](https://ai-sister.com)。作者 Ted Huang（[TED@TED-H.com](mailto:TED@TED-H.com)、[ted-h.com](https://ted-h.com)）。MIT License。

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ Ask one question, then let your logged-in **ChatGPT, Claude, Gemini, and Grok** 
 
 > **Project status:** Feature development is complete. The final optional AI-Sister four-character commemorative theme is included; future changes are limited to provider compatibility, security, and build breakage. The shipped snapshot/replay tools remain available as-is but have no further roadmap.
 
+## v1.4.0 highlights
+
+- **Restored conversations truly continue.** The first follow-up after reopening or switching a session replays a bounded transcript from that session only, while new conversations remain isolated.
+- **History is no longer overwritten.** Stable response identities keep new serial workflow answers from replacing restored bubbles.
+- **Higher-fidelity answers.** Provider DOM is converted into safe semantic Markdown with paragraphs, nested lists, links, fenced code, and GFM tables instead of flattened text.
+- **Calmer transcript scrolling.** Only the transcript pane follows new output; scrolling upward pauses auto-follow until a new message or session resumes it.
+- **Safer local persistence.** Old sessions are evicted only for recognized storage-quota failures, and the sidebar reflects what was actually saved.
+- **More reliable ChatGPT input.** Adapter v5 repairs stale or mismatched rich-editor drafts before sending and is also delivered through the existing adapter hot-update channel.
+
+See the bilingual [`v1.4.0 release notes`](./docs/RELEASE_NOTES_v1.4.0.md) for validation and known platform limits.
+
 ## Choose the right edition
 
 | Edition | Best for | How it runs |
@@ -22,8 +33,8 @@ Ask one question, then let your logged-in **ChatGPT, Claude, Gemini, and Grok** 
 - **Reliable offscreen automation.** Providers keep working without manually opening each “live page”; rejected sends retry and fail clearly instead of waiting forever.
 - **Conversation-first layout.** Workflow controls sit above the less-important provider WebView on the left; the transcript and composer keep the larger right pane.
 - **Five guided modes.** Free distribution, debate, consultation, coding, and five-round truth-seeking roundtable.
-- **Local sessions.** Create a new conversation or reopen up to 30 recent transcripts stored on this computer.
-- **Readable results.** Safe Markdown rendering for headings, lists, links, quotes, and code blocks.
+- **Local sessions.** Create a new conversation or reopen up to 30 recent transcripts stored on this computer; restored follow-ups receive bounded context from the same session.
+- **Readable results.** Safe semantic Markdown rendering for headings, nested lists, links, quotes, fenced code, and scrollable tables.
 - **Image completion.** Image-only ChatGPT responses complete the workflow instead of hanging.
 - **Reproducible work.** Optional snapshots, privacy tiers, replay, provider diagnostics, and a 2,000-event deduplicated log.
 - **Four UI languages.** English, Traditional Chinese, Japanese, and German.
@@ -158,6 +169,12 @@ pnpm tauri dev
 ## Project
 
 Report vulnerabilities privately through [`SECURITY.md`](./SECURITY.md). Report provider automation regressions with the GitHub **Adapter broken** issue form after reviewing the in-app diagnostic preview.
+
+### Contributors and acknowledgements
+
+Special thanks to [Dave Tseng (`@DaveTseng2019`)](https://github.com/DaveTseng2019) for the `v1.3.1` overlay reliability fix, the careful reproductions and original proposals in [#10](https://github.com/teddashh/multi-ai-chat-desktop/pull/10), [#11](https://github.com/teddashh/multi-ai-chat-desktop/pull/11), and [#12](https://github.com/teddashh/multi-ai-chat-desktop/pull/12), and the serializer regression tests merged in [#14](https://github.com/teddashh/multi-ai-chat-desktop/pull/14).
+
+Thank you to the Windows and macOS users who shared reproducible reports and sanitized debug logs. Those reports directly improved first-launch packaging, provider automation, session continuity, and release verification.
 
 Sponsored by [AI-Sister.com](https://ai-sister.com). Created by Ted Huang ([TED@TED-H.com](mailto:TED@TED-H.com), [ted-h.com](https://ted-h.com)).
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -10,6 +10,17 @@
 
 > **專案狀態：** 功能開發已完成，最後一套可選的 AI-Sister 四角色同框紀念 Theme 已加入；之後僅維護 provider 相容性、安全問題與 build 失敗。現有 snapshot／replay 會原樣保留，但不再擴充。
 
+## v1.4.0 更新重點
+
+- **重新開啟的對話真的能延續。** 切換或恢復 session 後的第一個追問，只會有限度地帶入同一 session 的舊對話；新對話仍保持完全隔離。
+- **舊訊息不再被覆寫。** 穩定的 response identity 可避免新的序列 workflow 回答蓋掉已恢復的對話泡泡。
+- **回答格式更完整。** Provider DOM 會轉成安全的語意化 Markdown，保留段落、巢狀清單、連結、fenced code 與 GFM 表格，不再全部攤平成純文字。
+- **捲動不再搶畫面。** 只捲動 transcript；使用者往上閱讀時會暫停跟隨，送出新訊息或切換 session 才恢復。
+- **本機儲存更安全。** 只有確認為 storage quota 問題時才淘汰最舊 session，側邊欄也會與真正存入的資料一致。
+- **ChatGPT 輸入更可靠。** Adapter v5 會在送出前修復殘留或不一致的 rich-editor 草稿，並可透過既有 adapter hot-update 通道下發。
+
+完整驗證與已知平台限制請見雙語版 [`v1.4.0 發布說明`](./docs/RELEASE_NOTES_v1.4.0.md)。
+
 ## 選擇適合的版本
 
 | 版本 | 適合情境 | 執行方式 |
@@ -22,8 +33,8 @@
 - **可靠的離屏自動化。** 不必逐家點進「真實頁面」；送出未被接受時會重試，真的失敗就明確回報，不再無限等待。
 - **以對話為主的版面。** 模式卡片、說明與等待狀態移到左側 provider WebView 上方；右側保留更大的逐字稿與輸入區。
 - **五種引導模式。** 自由分送、四方辯證、多方諮詢、Coding、五輪道理辯證。
-- **本機 session。** 可新增對話，或開啟最多 30 個只保存在這台電腦的近期 transcript。
-- **Markdown 結果。** 安全顯示標題、清單、連結、引用與程式碼區塊。
+- **本機 session。** 可新增對話，或開啟最多 30 個只保存在這台電腦的近期 transcript；恢復後的追問只帶入同一 session 的有限上下文。
+- **Markdown 結果。** 安全顯示標題、巢狀清單、連結、引用、fenced code 與可橫向捲動的表格。
 - **圖片完成判定。** ChatGPT 只產生圖片、沒有文字時也能結束流程。
 - **可重現執行。** 可選 snapshot、隱私分級、replay、provider 診斷與 2,000 筆去重 log。
 - **四種 UI 語言。** English、繁體中文、日本語、Deutsch。
@@ -158,6 +169,12 @@ pnpm tauri dev
 ## 專案資訊
 
 安全漏洞請依 [`SECURITY.md`](./SECURITY.md) 私下回報。Provider 自動化失效時，請先檢查 app 產生的診斷預覽，再使用 GitHub 的 **Adapter broken** 表單。
+
+### 貢獻者與致謝
+
+特別感謝 [Dave Tseng（`@DaveTseng2019`）](https://github.com/DaveTseng2019)：他貢獻了 `v1.3.1` 的 overlay 可靠性修正，在 [#10](https://github.com/teddashh/multi-ai-chat-desktop/pull/10)、[#11](https://github.com/teddashh/multi-ai-chat-desktop/pull/11)、[#12](https://github.com/teddashh/multi-ai-chat-desktop/pull/12) 提供仔細的重現與原始修法，並在 [#14](https://github.com/teddashh/multi-ai-chat-desktop/pull/14) 補上已合併的 serializer regression tests。
+
+也感謝提供可重現回報與已清理 debug log 的 Windows、macOS 使用者；這些資料直接改善了第一次啟動封裝、provider 自動化、session 延續與 release 驗證。
 
 Sponsored by [AI-Sister.com](https://ai-sister.com)。作者 Ted Huang（[TED@TED-H.com](mailto:TED@TED-H.com)、[ted-h.com](https://ted-h.com)）。
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Compatibility and Smoke-Test Matrix / 相容性與人工測試矩陣
 
-> Last reviewed: 2026-07-12. This document records evidence, not a guarantee. Provider DOM and login flows can change without notice.
+> Last reviewed: 2026-07-15. This document records evidence, not a guarantee. Provider DOM and login flows can change without notice.
 
 ## Status legend
 
@@ -23,8 +23,8 @@ macOS remains ad-hoc signed, not Developer ID signed or notarized. The Apple Sil
 
 | Evidence | Windows | macOS / Linux | Status |
 |---|---|---|---|
-| Manifest/schema and Skill drift tests | 20 focused tests pass locally | Cross-platform CI job configured; awaiting the first merged run of this contract | Windows **Verified**; others **Pending** |
-| Doctor/audit/dry-run JSON | Exercised locally; dry-run preserves runtime state | Same Node entrypoints covered by the platform matrix after merge | Windows **Verified**; others **Pending** |
+| Manifest/schema and Skill drift tests | 20 focused tests pass locally | The same 20 tests pass in Windows, macOS, and Linux CI jobs | **Verified** as a source contract; GUI launch remains separate |
+| Doctor/audit/dry-run JSON | Exercised locally; dry-run preserves runtime state | Node contract paths pass on all three CI operating systems | Windows **Verified**; others **CI-only** |
 | App-level READY wait | Three live source-launch smokes reached the same-run, identity-verified control-pane READY marker on 2026-07-12; stale/replacement/missing-state tests also pass | No real-device source-launch report | Windows **Verified**; others **Pending** |
 | Launch/stop race safety | Live smokes released the fail-closed launch mutex; audit probes detected generated/target/runtime changes; stop re-verified before kill and before same-run state deletion; foreign/EPERM tests pass | Same code path, not manually exercised | Windows **Verified**; others **Pending** |
 | Corrupt state recovery | Default stop refused malformed state and preserved it; explicit `--clear-invalid-state` removed only the state file, then a normal launch/stop completed | Not manually exercised | Windows **Verified**; others **Pending** |
@@ -35,7 +35,7 @@ The Agent contract does not claim that CI displayed a window. It also does not i
 
 | Provider | Bundled adapter | Windows text workflow evidence | Image-only completion |
 |---|---:|---|---|
-| ChatGPT | v4 | **Verified** | Partial manual coverage; recheck after provider UI changes |
+| ChatGPT | v5 | v4 text workflow **Verified**; v5 mismatch recovery has automated coverage and awaits live retest | Partial manual coverage; recheck after provider UI changes |
 | Claude | v3 | **Verified** | Not a compatibility claim |
 | Gemini | v1 | **Verified** | Not a compatibility claim |
 | Grok | v6 | **Verified** | Not a compatibility claim |
@@ -52,6 +52,10 @@ macOS note: the `v1.0.1` report verified ChatGPT, Claude, and Gemini login, but 
 | Debate / consultation / coding | Golden graph ordering and prompt-threading tests | Complete one run; verify role labels and final summary |
 | Roundtable | Five-round, four-speaker history tests | Complete one run; verify prior same-session speeches remain available |
 | Session isolation | Conversation persistence and latest-snapshot matching tests | Create two sessions; confirm no messages or export provenance cross over |
+| Restored-session continuity | Stable response-identity and bounded same-session replay tests | Reopen a session, ask a follow-up, and confirm old context is available without cross-session leakage |
+| Response fidelity | DOM-to-Markdown tests for paragraphs, nested lists, links, fenced code, direct/nested tables, and image-only fallback | Compare a provider answer containing code and a table with the captured transcript |
+| Transcript scrolling | Near-bottom and user-scroll intent tests | Stream a long answer, scroll upward, and confirm the app shell and reading position remain stable |
+| Session quota recovery | Quota-only eviction, transient-failure preservation, and persisted-state result tests | Fill local history near quota and confirm only the oldest sessions are removed |
 | Snapshot / replay | Schema, redaction, version mismatch, replay, and app-version tests | Save/replay once when local snapshot persistence is enabled |
 | Markdown export | Formatting and provenance tests | Confirm UTC time, app version, latest matching workflow/snapshot, and adapter versions |
 | Adapter hot update | Rust validation, version gate, cache, and URL-scope tests | Use a higher-version test adapter on an allowed host scope |

--- a/docs/RELEASE_NOTES_v1.4.0.md
+++ b/docs/RELEASE_NOTES_v1.4.0.md
@@ -1,0 +1,56 @@
+# v1.4.0 — Conversation continuity and answer fidelity
+
+## Stable maintenance release / 正式維護版本
+
+Multi-AI Chat Desktop `v1.4.0` makes restored conversations genuinely continuous, preserves more of each provider's answer structure, stops transcript streaming from moving the whole app, and hardens local session persistence. ChatGPT adapter v5 also repairs stale or mismatched editor drafts before sending.
+
+Multi-AI Chat Desktop `v1.4.0` 讓恢復後的對話能真正延續、保留更多 provider 回答結構、避免串流文字帶動整個 app 捲動，並強化本機 session 儲存。ChatGPT adapter v5 也會在送出前修復殘留或不一致的編輯器草稿。
+
+## Highlights / 更新重點
+
+- Restored sessions replay one bounded, same-session transcript on the first follow-up; new conversations remain isolated.
+- 恢復 session 後的第一個追問只會帶入同一 session 的有限歷史；新對話仍完全隔離。
+- Stable response identities prevent serial workflows from overwriting restored message bubbles.
+- 穩定的 response identity 可避免序列 workflow 覆寫已恢復的訊息。
+- Provider DOM is serialized into safe semantic Markdown with paragraphs, nested lists, links, fenced code, and tables; GFM tables render as scrollable tables.
+- Provider DOM 會轉成安全的語意化 Markdown，保留段落、巢狀清單、連結、fenced code 與表格；GFM 表格會以可捲動表格顯示。
+- Transcript auto-follow scrolls only the transcript container and pauses while the user reads older messages.
+- 自動跟隨只捲動 transcript；使用者閱讀舊訊息時不會被拉回底部。
+- Session eviction runs only for recognized quota failures, and the UI reflects the sessions that were actually persisted.
+- 只有確認為 quota 問題時才淘汰舊 session，UI 也會反映真正保存成功的資料。
+- ChatGPT adapter v5 replaces stale or mismatched rich-editor drafts before send and can reach existing installations through adapter hot-update.
+- ChatGPT adapter v5 會在送出前替換殘留或不一致的 rich-editor 草稿，並可透過 adapter hot-update 提供給既有安裝版。
+
+## Contributors / 貢獻者
+
+Special thanks to [Dave Tseng (`@DaveTseng2019`)](https://github.com/DaveTseng2019) for the `v1.3.1` overlay reliability fix; the detailed reproductions and original proposals in [#10](https://github.com/teddashh/multi-ai-chat-desktop/pull/10), [#11](https://github.com/teddashh/multi-ai-chat-desktop/pull/11), and [#12](https://github.com/teddashh/multi-ai-chat-desktop/pull/12); and the serializer regression tests merged in [#14](https://github.com/teddashh/multi-ai-chat-desktop/pull/14).
+
+特別感謝 [Dave Tseng（`@DaveTseng2019`）](https://github.com/DaveTseng2019)：他貢獻了 `v1.3.1` overlay 可靠性修正、在 [#10](https://github.com/teddashh/multi-ai-chat-desktop/pull/10)、[#11](https://github.com/teddashh/multi-ai-chat-desktop/pull/11)、[#12](https://github.com/teddashh/multi-ai-chat-desktop/pull/12) 提供詳細重現與原始方案，並在 [#14](https://github.com/teddashh/multi-ai-chat-desktop/pull/14) 補上已合併的 serializer regression tests。
+
+Thank you as well to community testers who shared reproducible Windows and macOS reports and sanitized debug logs.
+
+也感謝提供 Windows、macOS 可重現回報與已清理 debug log 的社群測試者。
+
+## Validation / 驗證
+
+- Local release gates pass: 368 frontend tests, 20 Agent contract tests, adapter schema checks, TypeScript type-checking, ESLint, 52 Rust tests, `cargo fmt --check`, and Clippy with warnings denied.
+- 本機發布閘門全數通過：368 個前端測試、20 個 Agent contract 測試、adapter schema 檢查、TypeScript type-check、ESLint、52 個 Rust 測試、`cargo fmt --check`，以及 warnings denied 的 Clippy。
+- GitHub CI passes frontend checks plus Clippy on Windows, macOS, and Linux with warnings denied.
+- The release workflow rebuilds and verifies Windows installer/portable, Apple Silicon DMG, and Linux AppImage artifacts from the immutable `v1.4.0` tag.
+- macOS packaging is ad-hoc signed and signature-checked, but not Apple-notarized.
+- Live Grok completion through a macOS Cloudflare challenge remains dependent on third-party behavior and has not been confirmed on a maintainer-owned Apple Silicon device.
+
+## Downloads / 下載
+
+- Windows x64 installer and portable zip
+- Apple Silicon macOS DMG
+- Linux x86_64 AppImage
+
+## Notes / 注意事項
+
+- No provider API keys are required; prompts go directly to the logged-in provider pages selected by the user.
+- Windows artifacts are unsigned and may trigger SmartScreen.
+- The macOS package is ad-hoc signed rather than Apple-notarized; follow the README first-launch steps if macOS blocks it.
+- Provider websites can change independently. Attach a sanitized exported debug log when reporting automation failures.
+
+**Full changelog:** https://github.com/teddashh/multi-ai-chat-desktop/compare/v1.3.1...v1.4.0


### PR DESCRIPTION
## Summary

- document the v1.4.0 conversation continuity, response fidelity, scrolling, persistence, and ChatGPT adapter improvements
- update English, Traditional Chinese, Japanese, and German READMEs with equivalent release guidance
- credit Dave Tseng and community testers for the reports, proposals, fixes, and regression coverage included in this maintenance release
- refresh compatibility evidence and add bilingual release notes

## Validation

- `pnpm verify` (368 frontend tests, 20 Agent contract tests, typecheck, lint, adapter checks)
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` (52 tests)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`

## Release impact

After this PR is merged, the immutable `v1.4.0` tag will build Windows installer/portable, Apple Silicon DMG, and Linux AppImage artifacts. The generated draft will be verified, completed with the checked-in release notes, and published as stable.
