### PR TITLE
fix: prevent response language policy echoes

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -70,7 +70,7 @@ macOS note: the `v1.0.1` report verified ChatGPT, Claude, and Gemini login, but 
 4. Run Free mode and one serial mode; cancel one in-progress run.
 5. Generate an image on a supporting provider and confirm the workflow reaches completion without relying on text-only output.
 6. Export Markdown and inspect provenance; create a new app session and verify history isolation.
-7. Open Settings, check for updates, switch themes and interface languages, and review the author/sponsor links. With Response language set to Auto, verify an English question receives English text and a Traditional Chinese question receives Traditional Chinese text regardless of the interface language; then verify a fixed response-language choice.
+7. Open Settings, check for updates, switch themes and interface languages, and review the author/sponsor links. With Response language set to Auto, verify an English question receives English text and a Traditional Chinese question receives Traditional Chinese text regardless of the interface language; then verify a fixed response-language choice. In particular, confirm Grok answers the request instead of reproducing the internal `<response-language-policy>` block.
 8. Export a sanitized debug bundle only if a failure occurs; never attach secrets or raw provider-page content.
 
 ## 回報方式

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,9 +1,9 @@
 # SPEC — Multi-AI Chat Desktop (Tauri 2)
 
-> Status: **v2.2.4 feature-frozen** (four-provider web edition; `v1.3.0` maintenance baseline)
-> Date: 2026-07-13
+> Status: **v2.2.5 feature-frozen** (four-provider web edition; `v1.4.0` maintenance baseline)
+> Date: 2026-07-15
 > Authority: `docs/PLAN.md` final-scope table supersedes every historical `NEXT-PHASE` note in this document and in `.orchestration/` material.
-> Review history: v1.0 DRAFT received adversarial codex + grok review; v1.2.1 live-gated the callback-pull bridge; v2.1 retired the fifth-provider experiment; v2.2 closes feature development after one final AI-Sister commemorative theme; v2.2.4 records the response-language compatibility repair without reopening feature development.
+> Review history: v1.0 DRAFT received adversarial codex + grok review; v1.2.1 live-gated the callback-pull bridge; v2.1 retired the fifth-provider experiment; v2.2 closes feature development after one final AI-Sister commemorative theme; v2.2.5 hardens the response-language compatibility repair against provider echo without reopening feature development.
 > Audience: maintenance contributors. Existing snapshot/replay/checkpoint behavior is compatibility-maintained but has no vNext roadmap.
 
 ## 0. One-paragraph summary
@@ -27,7 +27,7 @@ A Tauri 2 desktop app with one main window: a React control pane and child webvi
 2. **Step timeout UI** — 600s timeout surfaced with countdown + retry + skip (ARCH D5 #2), plus serial-mode preflight (§9.5).
 3. **Explicit bus routing** — replaces Chrome implicit broadcast (ARCH D5 #3).
 4. **Functional free-mode `targets`** — user may deselect providers for free mode; default (nothing deselected) = all sendable = original fan-out parity (golden-tested).
-5. **Response-language routing repair** — interface language controls app chrome, not provider output. The separate response-language preference defaults to `auto`: an explicit request wins, followed by current-question language, established user conversation language, then resolved interface locale. The resulting policy is appended centrally to every provider-bound workflow prompt and must ignore workflow copy, relayed AI text, quotations, attachments, code, URLs, and filenames as language evidence. A fixed response language may be selected, while an explicit per-question request remains authoritative.
+5. **Response-language routing repair** — interface language controls app chrome, not provider output. The separate response-language preference defaults to `auto`: an explicit request wins, followed by current-question language, established user conversation language, then resolved interface locale. The resulting policy is prepended centrally to every provider-bound workflow prompt so the actual request remains the final text, and it must ignore workflow copy, relayed AI text, quotations, attachments, code, URLs, and filenames as language evidence. A fixed response language may be selected, while an explicit per-question request remains authoritative. The bridge strips an exact or partially streamed internal policy echo before it can enter the transcript, snapshots, or downstream prompts; a policy-only final response becomes an explicit retryable provider error.
 
 Everything else must match the original extension's observable behavior. Any other deviation found in review is a bug.
 
@@ -688,6 +688,7 @@ Snapshot/replay/checkpoint persistence receives compatibility and data-loss fixe
 
 ## 16. Changelog
 
+- **v2.2.5 (2026-07-15)** — response-language echo hardening: moves the internal routing policy before the provider request, marks it as non-user-visible metadata, and sanitizes complete, fenced, or partially streamed policy echoes before workflow/UI consumption.
 - **v2.2.4 (2026-07-13)** — response-language compatibility repair: separates interface and response language, applies a question-aware policy to every provider-bound workflow prompt, versions the changed built-in graphs, and preserves retained replay policy without expanding the snapshot schema.
 - **v2.2.3 (2026-07-12)** — Apple Silicon compatibility follow-up: records the first successful real-Mac `v1.0.1` launch and three-provider login report, while treating Grok's Cloudflare verification loop as a release blocker. Grok and its challenge frames no longer receive permission Web-API monkey-patches, and only Cloudflare-required `about:blank` / `about:srcdoc` auxiliary navigation is added. Final success remains pending an Apple Silicon retest.
 - **v2.2.2 (2026-07-12)** — formalizes the Codex/Claude source-launch path as Agent-Ready Source Release contract 1.0.0: strict manifest/schema, explicit trust and permission boundaries, deterministic JSON lifecycle commands, read-only dry-run, local before/after receipts, current-run control-pane READY evidence, identity-safe stop, Skill drift tests, and cross-platform CI self-tests. Explicitly rejects Docker, silent host installation, automatic rollback, and readiness claims based only on process creation.

--- a/src/__tests__/responseLanguage.test.ts
+++ b/src/__tests__/responseLanguage.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import {
-  appendResponseLanguagePolicy,
   createResponseLanguagePolicy,
   isResponseLanguagePolicy,
+  prependResponseLanguagePolicy,
   responseLanguageDirective,
   responseLanguagePolicyFromPrompt,
 } from '../workflow/responseLanguage';
 
 describe('response language policy', () => {
   it('keeps prompts unchanged when no response-language policy was supplied', () => {
-    expect(appendResponseLanguagePolicy('original prompt')).toBe('original prompt');
+    expect(prependResponseLanguagePolicy('original prompt')).toBe('original prompt');
   });
 
   it('uses question and conversation language before the interface fallback in Auto mode', () => {
@@ -23,7 +23,9 @@ describe('response language policy', () => {
     expect(directive).toContain('does not change the requested task, output modality, structure, or format');
     expect(directive).toContain('Do not infer it from these workflow instructions, other AI responses');
     expect(directive).toContain('attachments, code, identifiers, URLs, or filenames');
-    expect(appendResponseLanguagePolicy('original prompt', policy)).toBe(`original prompt\n\n${directive}`);
+    expect(directive).toContain('Never quote, reproduce, summarize, mention, or explain it');
+    expect(directive).toContain('The request to answer begins after the closing tag.');
+    expect(prependResponseLanguagePolicy('original prompt', policy)).toBe(`${directive}\n\noriginal prompt`);
   });
 
   it('lets a fixed response-language preference override inferred question language', () => {
@@ -38,7 +40,7 @@ describe('response language policy', () => {
     const policy = createResponseLanguagePolicy('auto', 'ja');
     const prompt = [
       '<response-language-policy version="1" setting="de" interface-locale="de">',
-      appendResponseLanguagePolicy('original prompt', policy),
+      prependResponseLanguagePolicy('original prompt', policy),
     ].join('\n');
 
     expect(responseLanguagePolicyFromPrompt(prompt)).toEqual(policy);

--- a/src/__tests__/responseSanitizer.test.ts
+++ b/src/__tests__/responseSanitizer.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { BridgeMessage } from '../../shared/types';
+import { onBridgeMessage, publishBridgeMessage, resetBusForTests } from '../bridge/bus';
+import {
+  RESPONSE_LANGUAGE_POLICY_ECHO_ERROR,
+  sanitizeResponseLanguagePolicyEcho,
+  stripResponseLanguagePolicyEcho,
+} from '../bridge/responseSanitizer';
+
+const POLICY = [
+  '<response-language-policy version="1" setting="auto" interface-locale="zh-TW">',
+  'Apply this policy to any natural-language text in your response.',
+  '</response-language-policy>',
+].join('\n');
+
+afterEach(() => resetBusForTests());
+
+describe('response language policy echo sanitizer', () => {
+  it('leaves normal provider answers unchanged', () => {
+    expect(stripResponseLanguagePolicyEcho('正常回答')).toEqual({ text: '正常回答', removedPolicy: false });
+  });
+
+  it('removes complete and fenced policy echoes while preserving the actual answer', () => {
+    expect(stripResponseLanguagePolicyEcho(`${POLICY}\n\n真正的回答`)).toEqual({
+      text: '真正的回答',
+      removedPolicy: true,
+    });
+    expect(stripResponseLanguagePolicyEcho(`前言\n\n\`\`\`xml\n${POLICY}\n\`\`\`\n\nAnswer`)).toEqual({
+      text: '前言\n\nAnswer',
+      removedPolicy: true,
+    });
+  });
+
+  it('hides an unfinished cumulative streaming echo', () => {
+    expect(stripResponseLanguagePolicyEcho('<response-language-policy version="1" setting="auto" interface-locale="zh-TW">\nApply')).toEqual({
+      text: '',
+      removedPolicy: true,
+    });
+  });
+
+  it('turns a policy-only final response into a retryable error without losing payload metadata', () => {
+    const message: BridgeMessage = {
+      v: 1,
+      action: 'RESPONSE_DONE',
+      provider: 'grok',
+      payload: { text: POLICY, truncated: true },
+      transport: 'pull',
+    };
+
+    expect(sanitizeResponseLanguagePolicyEcho(message)).toMatchObject({
+      payload: { text: RESPONSE_LANGUAGE_POLICY_ECHO_ERROR, truncated: true },
+    });
+  });
+
+  it('sanitizes the central bridge stream before workflow and UI subscribers receive it', () => {
+    const received: BridgeMessage[] = [];
+    const cleanup = onBridgeMessage((message) => received.push(message));
+
+    publishBridgeMessage({
+      v: 1,
+      action: 'RESPONSE_DONE',
+      provider: 'grok',
+      payload: `${POLICY}\n\n實際答案`,
+      transport: 'pull',
+    });
+    cleanup();
+
+    expect(received).toHaveLength(1);
+    expect(received[0].payload).toBe('實際答案');
+  });
+});

--- a/src/__tests__/snapshotReplay.test.ts
+++ b/src/__tests__/snapshotReplay.test.ts
@@ -7,7 +7,7 @@ import { host } from '../host';
 import { resetCancelState } from '../workflow/cancel';
 import { executeGraph, workflowGraphs } from '../workflow/graph';
 import { resetWorkflowRuntimeForTests } from '../workflow/runtime';
-import { appendResponseLanguagePolicy, createResponseLanguagePolicy } from '../workflow/responseLanguage';
+import { createResponseLanguagePolicy, prependResponseLanguagePolicy } from '../workflow/responseLanguage';
 import { flushSessionCheckpointForTests, resetSessionCheckpointForTests } from '../workflow/sessionCheckpoint';
 import { getLastSnapshot, resetSnapshotRecorderForTests } from '../workflow/snapshot/recorder';
 import {
@@ -233,7 +233,7 @@ describe('snapshot replay', () => {
     const snapshot = buildSnapshot({
       steps: [
         step('pro', {
-          input: inlineRef(appendResponseLanguagePolicy(PROMPTS.debate.pro('clean replay question'), retainedPolicy)),
+          input: inlineRef(prependResponseLanguagePolicy(PROMPTS.debate.pro('clean replay question'), retainedPolicy)),
         }),
       ],
     });

--- a/src/__tests__/workflow.test.ts
+++ b/src/__tests__/workflow.test.ts
@@ -232,6 +232,8 @@ describe('workflow engine', () => {
       expect(prompt).toContain('<response-language-policy version="1" setting="auto" interface-locale="zh-TW">');
       expect(prompt).toContain('primary language of the user-authored prose');
       expect(prompt).toContain('Traditional Chinese (zh-TW) (the app interface language fallback)');
+      expect(prompt.startsWith('<response-language-policy')).toBe(true);
+      expect(prompt.endsWith('Explain dependency injection in simple terms.')).toBe(true);
     }
 
     vi.mocked(host.provider.send).mockClear();
@@ -257,6 +259,7 @@ describe('workflow engine', () => {
       ),
     ).toBe(true);
     expect(serialPrompts.every((prompt) => prompt.includes('Do not infer it from these workflow instructions, other AI responses'))).toBe(true);
+    expect(serialPrompts.every((prompt) => prompt.startsWith('<response-language-policy'))).toBe(true);
   });
 
   it('replays restored conversation context without replacing the current snapshot question', async () => {

--- a/src/bridge/bus.ts
+++ b/src/bridge/bus.ts
@@ -1,11 +1,13 @@
 import type { BridgeMessage } from '../../shared/types';
+import { sanitizeResponseLanguagePolicyEcho } from './responseSanitizer';
 
 type Handler = (message: BridgeMessage) => void;
 
 const handlers = new Set<Handler>();
 
 export function publishBridgeMessage(message: BridgeMessage): void {
-  for (const handler of [...handlers]) handler(message);
+  const sanitized = sanitizeResponseLanguagePolicyEcho(message);
+  for (const handler of [...handlers]) handler(sanitized);
 }
 
 export function onBridgeMessage(handler: Handler): () => void {

--- a/src/bridge/responseSanitizer.ts
+++ b/src/bridge/responseSanitizer.ts
@@ -1,0 +1,49 @@
+import type { BridgeMessage } from '../../shared/types';
+
+const COMPLETE_POLICY_ECHO_PATTERN =
+  /(?:```(?:xml)?[^\S\r\n]*(?:\r?\n)?)?<response-language-policy\b[^>]*>[\s\S]*?<\/response-language-policy>(?:[^\S\r\n]*(?:\r?\n)?```)?/giu;
+const PARTIAL_POLICY_ECHO_PATTERN =
+  /(?:```(?:xml)?[^\S\r\n]*(?:\r?\n)?)?<response-language-policy\b[^>]*>[\s\S]*$/iu;
+
+export const RESPONSE_LANGUAGE_POLICY_ECHO_ERROR =
+  '[Error: provider echoed an internal response-language instruction instead of answering; please retry]';
+
+export interface SanitizedResponseText {
+  text: string;
+  removedPolicy: boolean;
+}
+
+export function stripResponseLanguagePolicyEcho(text: string): SanitizedResponseText {
+  const withoutCompleteBlocks = text.replace(COMPLETE_POLICY_ECHO_PATTERN, '');
+  const withoutPartialBlock = withoutCompleteBlocks.replace(PARTIAL_POLICY_ECHO_PATTERN, '');
+  const removedPolicy = withoutPartialBlock !== text;
+  if (!removedPolicy) return { text, removedPolicy: false };
+  return {
+    text: withoutPartialBlock.replace(/\r\n/g, '\n').replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim(),
+    removedPolicy: true,
+  };
+}
+
+export function sanitizeResponseLanguagePolicyEcho(message: BridgeMessage): BridgeMessage {
+  if (message.action !== 'RESPONSE_CHUNK' && message.action !== 'RESPONSE_DONE') return message;
+
+  const final = message.action === 'RESPONSE_DONE';
+  if (typeof message.payload === 'string') {
+    const sanitized = stripResponseLanguagePolicyEcho(message.payload);
+    if (!sanitized.removedPolicy) return message;
+    return { ...message, payload: sanitized.text || (final ? RESPONSE_LANGUAGE_POLICY_ECHO_ERROR : '') };
+  }
+
+  if (!message.payload || typeof message.payload !== 'object' || !('text' in message.payload)) return message;
+  const payload = message.payload as Record<string, unknown>;
+  if (typeof payload.text !== 'string') return message;
+  const sanitized = stripResponseLanguagePolicyEcho(payload.text);
+  if (!sanitized.removedPolicy) return message;
+  return {
+    ...message,
+    payload: {
+      ...payload,
+      text: sanitized.text || (final ? RESPONSE_LANGUAGE_POLICY_ECHO_ERROR : ''),
+    },
+  };
+}

--- a/src/workflow/graph/executor.ts
+++ b/src/workflow/graph/executor.ts
@@ -5,7 +5,7 @@ import { awaitCheckpoint } from '../checkpoint';
 import { sendRoleAssignment, sendWorkflowStatus } from '../events';
 import { fillAndAwaitNativeSend } from '../nativeEdit';
 import { reserveProviderTurn, sendAndWait } from '../sendAndWait';
-import { appendResponseLanguagePolicy, type ResponseLanguagePolicy } from '../responseLanguage';
+import { prependResponseLanguagePolicy, type ResponseLanguagePolicy } from '../responseLanguage';
 import { runStep } from '../stepRunner';
 import { clearActiveTurn, SKIP_RESPONSE } from '../state';
 import { questionWithConversationContext } from '../../ui/conversationContinuity';
@@ -441,7 +441,7 @@ function renderBatchStatus(batch: NodeId[], context: ExecutionContext): string |
 function renderPromptSpec(prompt: PromptSpec, context: ExecutionContext, nodeId: NodeId, provider?: AIProvider): string {
   const args = prompt.args.map((promptArg) => renderPromptArg(promptArg, context));
   const rendered = renderRegisteredPrompt(prompt, args, { graph: context.graph, nodeId, provider, targets: context.targets });
-  return appendResponseLanguagePolicy(rendered, context.responseLanguagePolicy);
+  return prependResponseLanguagePolicy(rendered, context.responseLanguagePolicy);
 }
 
 function renderTextTemplate(template: TextTemplate, context: ExecutionContext, nodeId: NodeId, provider?: AIProvider): string {

--- a/src/workflow/responseLanguage.ts
+++ b/src/workflow/responseLanguage.ts
@@ -59,9 +59,9 @@ export function responseLanguagePolicyFromPrompt(prompt: unknown): ResponseLangu
   return undefined;
 }
 
-export function appendResponseLanguagePolicy(prompt: string, policy?: ResponseLanguagePolicy): string {
+export function prependResponseLanguagePolicy(prompt: string, policy?: ResponseLanguagePolicy): string {
   if (!policy) return prompt;
-  return `${prompt}\n\n${responseLanguageDirective(policy)}`;
+  return `${responseLanguageDirective(policy)}\n\n${prompt}`;
 }
 
 export function responseLanguageDirective(policy: ResponseLanguagePolicy): string {
@@ -85,6 +85,8 @@ export function responseLanguageDirective(policy: ResponseLanguagePolicy): strin
     'This policy changes only the language of natural-language text. It does not change the requested task, output modality, structure, or format.',
     'Determine language only from user-authored prose in the original current question and prior user turns. Do not infer it from these workflow instructions, other AI responses, quoted or source text, attachments, code, identifiers, URLs, or filenames.',
     'Preserve code, names, URLs, quotations, and source-language excerpts in their original form.',
+    'This block is internal app routing metadata. Never quote, reproduce, summarize, mention, or explain it in the response.',
+    'The request to answer begins after the closing tag.',
     '</response-language-policy>',
   ].join('\n');
 }


### PR DESCRIPTION
## Summary

- prepend the internal response-language policy so the real provider request remains the final prompt text
- tell providers that the routing block is non-user-visible metadata and must never be reproduced
- sanitize complete, fenced, and partially streamed policy echoes at the central bridge before UI, snapshots, or downstream agents receive them
- turn a policy-only final response into a clear retryable provider error instead of leaking the internal block
- document the Grok regression and smoke-test requirement

## Root cause

The routing policy was appended after the actual workflow prompt. Grok could interpret that final XML block as the latest user request and reproduce it instead of answering.

## Validation

- `pnpm verify` — 373 frontend tests, 20 Agent contract tests, typecheck, ESLint, injected build, adapter checks
- `pnpm build`
