### PR TITLE
fix: ignore provider prompt echoes

### DIFF
--- a/injected/engine.ts
+++ b/injected/engine.ts
@@ -58,6 +58,41 @@ const SEND_BUTTON_SELECTOR_TIMEOUT_MS = 800;
 const PRE_SEND_DELAY_MS = 800;
 const SEND_RETRY_DELAY_MS = 1500;
 const SEND_FINAL_VERIFY_DELAY_MS = 1500;
+const USER_MESSAGE_ANCESTOR_SELECTOR = [
+  '[data-message-author-role="user"]',
+  '[data-testid="user-message"]',
+  'div[id^="response-"].items-end',
+  '.message-bubble.user',
+].join(', ');
+
+export function isLikelyPromptEcho(responseText: string, promptText: string): boolean {
+  const trimmedResponse = responseText.trim();
+  const trimmedPrompt = promptText.trim();
+  if (trimmedResponse && trimmedResponse === trimmedPrompt) return true;
+
+  const responseKey = promptEchoComparisonKey(responseText);
+  const promptKey = promptEchoComparisonKey(promptText);
+  if (!responseKey || !promptKey) return false;
+  if (responseKey === promptKey) return true;
+
+  const shorterLength = Math.min(responseKey.length, promptKey.length);
+  const longerLength = Math.max(responseKey.length, promptKey.length);
+  if (shorterLength < 40 || shorterLength / longerLength < 0.9) return false;
+  if (responseKey.includes(promptKey) || promptKey.includes(responseKey)) return true;
+
+  const sampleLength = Math.min(80, Math.floor(shorterLength / 3));
+  return (
+    responseKey.slice(0, sampleLength) === promptKey.slice(0, sampleLength) &&
+    responseKey.slice(-sampleLength) === promptKey.slice(-sampleLength)
+  );
+}
+
+function promptEchoComparisonKey(value: string): string {
+  return value
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[\p{P}\p{S}\s]+/gu, '');
+}
 
 export async function retryLookup<T>(lookup: () => T | null | undefined, options: RetryLookupOptions = {}): Promise<T | null> {
   const intervalMs = Math.max(1, options.intervalMs ?? SELECTOR_RETRY_INTERVAL_MS);
@@ -106,6 +141,7 @@ class InputInjectionError extends Error {
   let responseBaselineEls = new Set<Element>();
   let waitingForResponse = false;
   let lastResponseText = '';
+  let pendingPromptText = '';
   let lastChunkTime = 0;
 
   window.__MAC_ENGINE__ = {
@@ -246,6 +282,7 @@ class InputInjectionError extends Error {
     responseBaselineEls = new Set(existingResponses);
     waitingForResponse = true;
     lastResponseText = '';
+    pendingPromptText = text;
     startResponsePolling();
 
     const injectionStartedAt = Date.now();
@@ -488,10 +525,21 @@ class InputInjectionError extends Error {
     for (let index = responseEls.length - 1; index >= 0; index -= 1) {
       const response = responseEls[index];
       if (waitingForResponse && responseBaselineEls.has(response)) continue;
+      if (isUserMessageElement(response)) continue;
       const text = extractResponseText(response);
-      if (text) return text;
+      if (text && !isLikelyPromptEcho(text, pendingPromptText)) return text;
     }
     return null;
+  }
+
+  function isUserMessageElement(response: Element): boolean {
+    const closest = (response as Element & { closest?: (selector: string) => Element | null }).closest;
+    if (typeof closest !== 'function') return false;
+    try {
+      return Boolean(closest.call(response, USER_MESSAGE_ANCESTOR_SELECTOR));
+    } catch {
+      return false;
+    }
   }
 
   function extractResponseText(response: Element): string | null {
@@ -539,7 +587,9 @@ class InputInjectionError extends Error {
     waitingForResponse = false;
     clearTimersForResponse();
     responseBaselineEls.clear();
-    bridge.emit({ v: 1, action: 'RESPONSE_DONE', provider: adapter.provider, payload: lastResponseText });
+    const payload = lastResponseText;
+    pendingPromptText = '';
+    bridge.emit({ v: 1, action: 'RESPONSE_DONE', provider: adapter.provider, payload });
   }
 
   function doneWithError(reason: string, providerHint?: AIProvider) {
@@ -548,6 +598,7 @@ class InputInjectionError extends Error {
     waitingForResponse = false;
     clearTimersForResponse();
     responseBaselineEls.clear();
+    pendingPromptText = '';
     bridge.emit({ v: 1, action: 'RESPONSE_DONE', provider, payload: `[Error: ${reason}]` });
   }
 

--- a/src/__tests__/engine-input.test.ts
+++ b/src/__tests__/engine-input.test.ts
@@ -84,6 +84,20 @@ describe('injected engine input hardening', () => {
     expect(attempts).toBeGreaterThan(1);
   });
 
+  it('recognizes a rendered copy of the pending prompt without hiding a substantive answer', async () => {
+    vi.resetModules();
+    const { isLikelyPromptEcho } = await import('../../injected/engine');
+
+    expect(
+      isLikelyPromptEcho(
+        '請比較 A 與 B。\n\n完整內容',
+        '請比較 **A** 與 `B`。\n\n---\n\n完整內容',
+      ),
+    ).toBe(true);
+    expect(isLikelyPromptEcho('你好', '你好')).toBe(true);
+    expect(isLikelyPromptEcho('結論：A 較適合，原因是成本較低。', '請比較 A 與 B。')).toBe(false);
+  });
+
   it('lets assertInputLanded pass when the injected text is visible', async () => {
     vi.useFakeTimers();
     const env = createEnv({ inputKind: 'textarea' });
@@ -343,6 +357,83 @@ describe('injected engine input hardening', () => {
 
     expect(env.emitted).toContainEqual({ v: 1, action: 'RESPONSE_CHUNK', provider: 'grok', payload: 'native answer' });
     expect(env.emitted).toContainEqual({ v: 1, action: 'RESPONSE_DONE', provider: 'grok', payload: 'native answer' });
+  });
+
+  it('ignores a newly rendered user prompt until the provider answer starts', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea' });
+    const handler = await installEngine(env);
+    dispatchAdapter(handler, {
+      timing: {
+        doneDelayMs: 10,
+        chunkDebounceMs: 0,
+        statusIntervalMs: 1_000_000,
+        backupPollMs: 10,
+      },
+    });
+    const prompt = '請比較 **A** 與 `B`。\n\n---\n\n完整內容';
+
+    send(handler, prompt);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(PRE_SEND_DELAY_MS);
+    env.input.setVisibleText('');
+    const promptBubble = new FakeElement(env.document, 'div', '請比較 A 與 B。\n\n完整內容');
+    env.responses = [promptBubble];
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(env.emitted.some((message) => message.action === 'RESPONSE_CHUNK')).toBe(false);
+    expect(env.emitted.some((message) => message.action === 'RESPONSE_DONE')).toBe(false);
+
+    env.responses = [promptBubble, new FakeElement(env.document, 'div', 'A 較適合，原因是成本較低。')];
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(env.emitted).toContainEqual({
+      v: 1,
+      action: 'RESPONSE_CHUNK',
+      provider: 'grok',
+      payload: 'A 較適合，原因是成本較低。',
+    });
+    expect(env.emitted).toContainEqual({
+      v: 1,
+      action: 'RESPONSE_DONE',
+      provider: 'grok',
+      payload: 'A 較適合，原因是成本較低。',
+    });
+    expect(env.emitted.some((message) => message.payload === '請比較 A 與 B。\n\n完整內容')).toBe(false);
+  });
+
+  it('captures only the latest response when a provider renders two candidates', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea' });
+    const handler = await installEngine(env);
+    dispatchAdapter(handler, {
+      timing: {
+        doneDelayMs: 10,
+        chunkDebounceMs: 0,
+        statusIntervalMs: 1_000_000,
+        backupPollMs: 10,
+      },
+    });
+
+    send(handler, '請直接回答');
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(PRE_SEND_DELAY_MS);
+    env.input.setVisibleText('');
+    env.responses = [
+      new FakeElement(env.document, 'div', '候選回答 A'),
+      new FakeElement(env.document, 'div', '候選回答 B'),
+    ];
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(env.emitted).toContainEqual({
+      v: 1,
+      action: 'RESPONSE_DONE',
+      provider: 'grok',
+      payload: '候選回答 B',
+    });
+    expect(env.emitted.some((message) => String(message.payload).includes('候選回答 A'))).toBe(false);
   });
 
   it('finishes an image-only response when the provider emits no markdown text', async () => {


### PR DESCRIPTION
## Summary
- ignore newly rendered user-message DOM nodes that broad provider response selectors can match
- reject response candidates that are formatting-equivalent to the pending prompt
- keep only the latest provider response when multiple candidates are rendered

## Root cause
The supplied v1.4.0 debug bundle shows every Grok turn first emitted a response chunk almost equal to the queued prompt length. On round 1, the real assistant response did not begin before Grok's 8-second completion delay, so the engine finalized the rendered user prompt as Grok's answer.

## Validation
- `pnpm verify` (376 frontend tests + 20 agent tests, typecheck, lint, adapter checks)
- `pnpm build`
