### PR TITLE
feat: scroll transcript to provider message on connection chip click

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,7 +56,7 @@ import { ReplayPanel, type ReplaySource } from './ui/ReplayPanel';
 import { SessionCheckpointNotice } from './ui/SessionCheckpointNotice';
 import { StepTimeoutDialog, type StepTimeoutDialogState } from './ui/StepTimeoutDialog';
 import { TargetChips } from './ui/TargetChips';
-import { isTranscriptNearEnd, scrollTranscriptToEnd } from './ui/transcriptScroll';
+import { isTranscriptNearEnd, scrollTranscriptToEnd, scrollTranscriptToProviderMessage } from './ui/transcriptScroll';
 import {
   DEFAULT_FOCUS_LAYOUT_CONSTRAINTS,
   clampFocusPaneWidth,
@@ -1777,6 +1777,10 @@ export default function App() {
               reportBusy={reportBusy}
               processTrace={processTrace}
               onTraceDetailOpenChange={setProcessTraceDetailOpen}
+              onChipClick={(provider) => {
+                const container = transcriptRef.current;
+                if (container) scrollTranscriptToProviderMessage(container, provider);
+              }}
             />
           </div>
         </div>

--- a/src/__tests__/transcriptScroll.test.ts
+++ b/src/__tests__/transcriptScroll.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { isTranscriptNearEnd, scrollTranscriptToEnd } from '../ui/transcriptScroll';
+import { isTranscriptNearEnd, scrollTranscriptToEnd, scrollTranscriptToProviderMessage } from '../ui/transcriptScroll';
 
 describe('transcript scrolling', () => {
   it('distinguishes reading older content from following the latest response', () => {
@@ -12,5 +12,45 @@ describe('transcript scrolling', () => {
     scrollTranscriptToEnd({ scrollHeight: 2_400, scrollTop: 200, clientHeight: 600, scrollTo });
 
     expect(scrollTo).toHaveBeenCalledWith({ top: 2_400, behavior: 'auto' });
+  });
+
+  const fakeBubble = () => ({
+    scrollIntoView: vi.fn(),
+    classList: { add: vi.fn(), remove: vi.fn() },
+  });
+
+  it('jumps to the latest message of the clicked provider so the user sees its part of the conversation', () => {
+    const older = fakeBubble();
+    const latest = fakeBubble();
+    const container = {
+      querySelectorAll: vi.fn((selector: string) => (selector === 'article[data-provider="chatgpt"]' ? [older, latest] : [])),
+    };
+
+    expect(scrollTranscriptToProviderMessage(container, 'chatgpt')).toBe(true);
+    expect(older.scrollIntoView).not.toHaveBeenCalled();
+    expect(latest.scrollIntoView).toHaveBeenCalledWith({ block: 'start' });
+  });
+
+  it('flashes a temporary highlight on the target message so the user can spot it', () => {
+    vi.useFakeTimers();
+    try {
+      const bubble = fakeBubble();
+      const container = { querySelectorAll: () => [bubble] };
+
+      scrollTranscriptToProviderMessage(container, 'chatgpt');
+
+      expect(bubble.classList.add).toHaveBeenCalledWith('transcript-provider-highlight');
+      expect(bubble.classList.remove).not.toHaveBeenCalled();
+      vi.runAllTimers();
+      expect(bubble.classList.remove).toHaveBeenCalledWith('transcript-provider-highlight');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('leaves the transcript alone when the provider never joined the conversation', () => {
+    const container = { querySelectorAll: () => [] };
+
+    expect(scrollTranscriptToProviderMessage(container, 'gemini')).toBe(false);
   });
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -33,6 +33,11 @@ textarea,
   display: none;
 }
 
+/* 靜態高亮 + JS 定時移除：不用 animation，避免 prefers-reduced-motion 把時長壓成 0 而看不到 */
+.transcript-provider-highlight {
+  box-shadow: 0 0 0 2px #0284c7;
+}
+
 html.ai-sister {
   color-scheme: dark;
   --ai-sister-ink: #f8f7ff;

--- a/src/ui/FocusPane.tsx
+++ b/src/ui/FocusPane.tsx
@@ -41,6 +41,7 @@ export function FocusPane({
   reportBusy,
   processTrace,
   onTraceDetailOpenChange,
+  onChipClick,
 }: {
   centeredProvider?: AIProvider;
   states: Record<AIProvider, ProviderState>;
@@ -62,6 +63,7 @@ export function FocusPane({
   reportBusy: boolean;
   processTrace?: ProcessTraceState;
   onTraceDetailOpenChange?: (open: boolean) => void;
+  onChipClick?: (provider: AIProvider) => void;
 }) {
   const { locale, t } = useI18n();
   const [providerAction, setProviderAction] = useState<ProviderActionState | undefined>();
@@ -132,6 +134,7 @@ export function FocusPane({
         setPaneRef={setPaneRef}
         activateProvider={activateProvider}
         openingProvider={openingProvider}
+        onChipClick={onChipClick}
       />
     </aside>
   );
@@ -420,6 +423,7 @@ function StatusStrip({
   setPaneRef,
   activateProvider,
   openingProvider,
+  onChipClick,
 }: {
   centeredProvider?: AIProvider;
   states: Record<AIProvider, ProviderState>;
@@ -427,6 +431,7 @@ function StatusStrip({
   setPaneRef: (provider: AIProvider, el: HTMLElement | null) => void;
   activateProvider: (provider: AIProvider) => Promise<void>;
   openingProvider?: AIProvider;
+  onChipClick?: (provider: AIProvider) => void;
 }) {
   const { t } = useI18n();
   return (
@@ -446,6 +451,7 @@ function StatusStrip({
             setPaneRef={setPaneRef}
             activateProvider={activateProvider}
             openingProvider={openingProvider}
+            onChipClick={onChipClick}
           />
         ))}
       </div>
@@ -461,6 +467,7 @@ function StatusStripItem({
   setPaneRef,
   activateProvider,
   openingProvider,
+  onChipClick,
 }: {
   provider: AIProvider;
   state: ProviderState;
@@ -469,10 +476,12 @@ function StatusStripItem({
   setPaneRef: (provider: AIProvider, el: HTMLElement | null) => void;
   activateProvider: (provider: AIProvider) => Promise<void>;
   openingProvider?: AIProvider;
+  onChipClick?: (provider: AIProvider) => void;
 }) {
   const { t } = useI18n();
   const status = chipState(state, presentation, t);
   const focusProvider = () => {
+    onChipClick?.(provider);
     if (centered && state.webview === 'loaded') return;
     void activateProvider(provider);
   };

--- a/src/ui/transcriptScroll.ts
+++ b/src/ui/transcriptScroll.ts
@@ -12,3 +12,28 @@ export function isTranscriptNearEnd(container: Pick<TranscriptScrollContainer, '
 export function scrollTranscriptToEnd(container: TranscriptScrollContainer, behavior: ScrollBehavior = 'auto'): void {
   container.scrollTo({ top: container.scrollHeight, behavior });
 }
+
+const HIGHLIGHT_CLASS = 'transcript-provider-highlight';
+const HIGHLIGHT_DURATION_MS = 1_600;
+
+export interface TranscriptProviderBubble {
+  scrollIntoView(options?: ScrollIntoViewOptions): void;
+  classList: { add(token: string): void; remove(token: string): void };
+}
+
+export interface TranscriptProviderLookup {
+  querySelectorAll(selector: string): ArrayLike<TranscriptProviderBubble>;
+}
+
+/** 捲到該 provider 最後一則訊息並短暫高亮；沒參與對話則不動。回傳是否有捲動。
+ * 限定 article：訊息內的頭像 span 也帶 data-provider，且在預設主題是 display:none，
+ * 對隱藏元素呼叫 scrollIntoView 不會捲動。 */
+export function scrollTranscriptToProviderMessage(container: TranscriptProviderLookup, provider: string): boolean {
+  const bubbles = container.querySelectorAll(`article[data-provider="${provider}"]`);
+  const last = bubbles[bubbles.length - 1];
+  if (!last) return false;
+  last.scrollIntoView({ block: 'start' });
+  last.classList.add(HIGHLIGHT_CLASS);
+  setTimeout(() => last.classList.remove(HIGHLIGHT_CLASS), HIGHLIGHT_DURATION_MS);
+  return true;
+}


### PR DESCRIPTION
## Problem

Clicking a provider chip under **AI connections** switches the centered browser view, but the conversation transcript on the right does not react. When an AI has already replied somewhere in the conversation, the user has to scroll around manually to find that reply.

## Cause

No wiring existed between the chip click and the transcript. A naive `[data-provider]` lookup also cannot work here: each message renders **two** elements with `data-provider` — the `<article>` bubble and the avatar `<span>` inside it. The avatar span is `display:none` in the default theme (`.ai-sister-only`), and `scrollIntoView` on a hidden element is a silent no-op.

## Fix

- `transcriptScroll.ts`: new `scrollTranscriptToProviderMessage()` — finds the provider's latest bubble via `article[data-provider="…"]`, scrolls it into view, and flashes a brief highlight ring (static class + timed removal rather than a CSS animation, so it stays visible under `prefers-reduced-motion`, which the global reset clamps to ~0ms).
- `FocusPane.tsx`: optional `onChipClick` threaded to `StatusStripItem`; fires even when the provider is already centered.
- `App.tsx`: wires the callback to the transcript container.
- `styles.css`: `.transcript-provider-highlight` ring using the app's focus color.

Providers that never joined the conversation leave the transcript untouched.

## Verification

- `npm run typecheck` and `npx vitest run` — 50 files / 380 tests pass (3 new tests cover latest-bubble targeting, no-participation no-op, and highlight add/remove).
- Manually verified in the browser (vite dev + seeded history): clicking Gemini/ChatGPT chips scrolls the transcript to that AI's latest reply and shows the highlight ring; scroll position confirmed via `scrollTop` before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)