### PR TITLE
fix: keep history dates stable when conversation content is unchanged

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import {
   loadConversationSessions,
   removeConversationSession,
   saveConversationSessionsWithQuotaRecovery,
+  sessionContentChanged,
   titleFromFirstUserMessage,
   upsertConversationSession,
   type ConversationSession,
@@ -453,10 +454,12 @@ export default function App() {
   useEffect(() => {
     const timer = window.setTimeout(() => {
       setSessions((current) => {
-        const existing = current.find((session) => session.id === activeSessionId) ?? createConversationSession({ id: activeSessionId, mode });
+        const existing = current.find((session) => session.id === activeSessionId);
         const storedMessages = conversationMessages(messages);
+        if (existing && !sessionContentChanged(existing, storedMessages, mode)) return current;
+        const base = existing ?? createConversationSession({ id: activeSessionId, mode });
         const next = upsertConversationSession(current, {
-          ...existing,
+          ...base,
           title: titleFromFirstUserMessage(storedMessages),
           updatedAt: Date.now(),
           mode,
@@ -1439,13 +1442,14 @@ export default function App() {
     const nextSession = createConversationSession({ now });
     setSessions((current) => {
       const existing = current.find((session) => session.id === activeSessionId);
-      const archived = existing
+      const storedMessages = conversationMessages(messages);
+      const archived = existing && sessionContentChanged(existing, storedMessages, mode)
         ? upsertConversationSession(current, {
             ...existing,
-            title: titleFromFirstUserMessage(conversationMessages(messages)),
+            title: titleFromFirstUserMessage(storedMessages),
             updatedAt: now,
             mode,
-            messages: conversationMessages(messages),
+            messages: storedMessages,
           })
         : current;
       const next = upsertConversationSession(archived, nextSession);

--- a/src/__tests__/conversationSessions.test.ts
+++ b/src/__tests__/conversationSessions.test.ts
@@ -11,6 +11,7 @@ import {
   removeConversationSession,
   saveConversationSessions,
   saveConversationSessionsWithQuotaRecovery,
+  sessionContentChanged,
   titleFromFirstUserMessage,
   upsertConversationSession,
   type ConversationSession,
@@ -147,6 +148,15 @@ describe('conversation sessions', () => {
     expect(normalized).toHaveLength(MAX_CONVERSATION_SESSIONS);
     expect(normalized[0]).toMatchObject({ id: 's-34', title: 'newest duplicate', updatedAt: 50 });
     expect(normalized.at(-1)?.id).toBe('s-5');
+  });
+
+  it('treats re-opening a conversation as unchanged so its sidebar date stays put', () => {
+    const messages = [{ id: 'user-1', role: 'user' as const, content: 'Hello', final: true }];
+    const existing = session('s-1', 10, { mode: 'free', messages });
+
+    expect(sessionContentChanged(existing, [...messages], 'free')).toBe(false);
+    expect(sessionContentChanged(existing, [...messages, { id: 'ai-1', role: 'ai', content: 'Reply' }], 'free')).toBe(true);
+    expect(sessionContentChanged(existing, [...messages], 'debate')).toBe(true);
   });
 
   it('removes only the named session and leaves the others intact', () => {

--- a/src/ui/conversationSessions.ts
+++ b/src/ui/conversationSessions.ts
@@ -137,6 +137,16 @@ export function normalizeConversationSessions(value: unknown): ConversationSessi
     .slice(0, MAX_CONVERSATION_SESSIONS);
 }
 
+/** 內容（訊息與模式）是否有實質變更。沒有變更就不該更新 updatedAt——
+ * 單純切換到舊對話或重新啟動不算「新的對話內容」，側欄日期不應跳動。 */
+export function sessionContentChanged(
+  existing: Pick<ConversationSession, 'mode' | 'messages'>,
+  messages: readonly ConversationSessionMessage[],
+  mode: ChatMode,
+): boolean {
+  return existing.mode !== mode || JSON.stringify(existing.messages) !== JSON.stringify(messages);
+}
+
 export function upsertConversationSession(
   sessions: readonly ConversationSession[],
   session: ConversationSession,


### PR DESCRIPTION
## Problem

Every conversation in the history sidebar shows today's date after an app start or after simply clicking through old conversations — the displayed timestamp no longer reflects when the conversation actually last changed.

## Cause

Two paths rewrite `updatedAt: Date.now()` unconditionally:

1. The debounced persistence effect fires on any `activeSessionId`/`messages`/`mode` change — including app startup and selecting an old conversation — and stamps the active session.
2. `startNewConversation` re-archives the current conversation with a fresh timestamp even when its content is identical to what is already stored.

## Fix

- `conversationSessions.ts`: new `sessionContentChanged(existing, messages, mode)` — content comparison of stored messages and mode.
- `App.tsx`: both paths skip the rewrite entirely when nothing changed (which also avoids redundant localStorage writes). Genuine new messages or a mode change still bump `updatedAt` as before.

## Verification

- `npm run typecheck` and `npx vitest run` — 50 files / 378 tests pass (new test: re-opening is unchanged; adding a message or changing mode counts as changed).
- Manually verified in the browser (vite dev, seeded sessions dated Jul 1 / Jun 20): after startup, after switching between the two conversations, and after clicking new-conversation, both stored `updatedAt` values and the sidebar dates stayed at Jul 1 / Jun 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)