### PR TITLE
fix: keep provider connections when switching history

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1488,18 +1488,7 @@ export default function App() {
       setReplayDrawerOpen(false);
       setTargetSelection({ targets: [...DEFAULT_FREE_TARGET_PROVIDERS], defaultsInitialized: true, userTouched: false });
       activeResponses.current.clear();
-      for (const provider of PROVIDERS) {
-        if (statesRef.current[provider].webview !== 'loaded') continue;
-        resetProviderBootState(provider);
-        void host.provider.newSession(provider).catch((reason) => {
-          recordEventLog({
-            kind: 'workflow-error',
-            provider,
-            summary: `${AI_PROVIDERS[provider].name} session restore reset failed`,
-            detail: { failure: reason instanceof Error ? reason.message : String(reason) },
-          });
-        });
-      }
+      // ponytail: 切換歷史只換本地畫面，provider webview 保持原連線不重連
     },
     [activeSessionId, isProcessing],
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ import {
   buildConversationReplayContext,
   createActiveProviderResponse,
   createConversationMessageId,
+  ensureFreshProviderSessions,
   type ActiveProviderResponse,
 } from './ui/conversationContinuity';
 import { FocusPane, type CenterSurface } from './ui/FocusPane';
@@ -353,6 +354,7 @@ export default function App() {
   const replayContextSessionRef = useRef<string | undefined>(
     initialConversation.active.messages.length > 0 ? initialConversation.active.id : undefined,
   );
+  const pendingProviderResetRef = useRef<Set<AIProvider>>(new Set());
   const pullBridge = useRef(new Map<AIProvider, PullBridgeState>());
   const replayPanelRef = useRef<ReplayPanel | null>(null);
   const targets = targetSelection.targets;
@@ -1357,6 +1359,28 @@ export default function App() {
     ]);
     setIsProcessing(processingAfterSend());
     setProcessTrace(createProcessTrace(mode, workflowTargets ?? [], localeRef.current));
+    if (pendingProviderResetRef.current.size > 0) {
+      const providersToFreshen = [...pendingProviderResetRef.current].filter(
+        (provider) => statesRef.current[provider].webview === 'loaded',
+      );
+      pendingProviderResetRef.current.clear();
+      if (providersToFreshen.length > 0) {
+        await ensureFreshProviderSessions(providersToFreshen, {
+          resetBootState: resetProviderBootState,
+          newSession: (provider) =>
+            host.provider.newSession(provider).catch((reason) => {
+              recordEventLog({
+                kind: 'workflow-error',
+                provider,
+                summary: `${AI_PROVIDERS[provider].name} session restore reset failed`,
+                detail: { failure: reason instanceof Error ? reason.message : String(reason) },
+              });
+            }),
+          isDomReady: (provider) => statesRef.current[provider].dom === 'ready',
+          wait: () => new Promise((resolve) => setTimeout(resolve, 150)),
+        });
+      }
+    }
     const workflowStartedAt = Date.now();
     const snapshotSettings = settingsRef.current;
     const workflowRoles = defaultRolesForPreset(mode);
@@ -1473,6 +1497,7 @@ export default function App() {
     setReplayDrawerOpen(false);
     setTargetSelection({ targets: [...DEFAULT_FREE_TARGET_PROVIDERS], defaultsInitialized: true, userTouched: false });
     activeResponses.current.clear();
+    pendingProviderResetRef.current.clear();
     for (const provider of PROVIDERS) {
       if (statesRef.current[provider].webview !== 'loaded') continue;
       resetProviderBootState(provider);
@@ -1500,7 +1525,9 @@ export default function App() {
       setReplayDrawerOpen(false);
       setTargetSelection({ targets: [...DEFAULT_FREE_TARGET_PROVIDERS], defaultsInitialized: true, userTouched: false });
       activeResponses.current.clear();
-      // ponytail: 切換歷史只換本地畫面，provider webview 保持原連線不重連
+      // 切換歷史只換本地畫面，保留 provider webview 原連線（不重連）讓使用者能繼續瀏覽；
+      // 遠端 thread 仍屬於前一個 session，真正送出前 executeSend 會先建立乾淨 provider session。
+      pendingProviderResetRef.current = new Set(PROVIDERS.filter((provider) => statesRef.current[provider].webview === 'loaded'));
     },
     [activeSessionId, isProcessing],
   );

--- a/src/__tests__/conversationContinuity.test.ts
+++ b/src/__tests__/conversationContinuity.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   buildConversationReplayContext,
   createActiveProviderResponse,
   createConversationMessageId,
+  ensureFreshProviderSessions,
   questionWithConversationContext,
+  type ProviderSessionResetHost,
 } from '../ui/conversationContinuity';
 
 describe('conversation continuity', () => {
@@ -42,5 +44,44 @@ describe('conversation continuity', () => {
     expect(prompt).toContain('Claude:\nPrevious answer');
     expect(prompt.endsWith('Current user question:\nWhat changed?')).toBe(true);
     expect(questionWithConversationContext('Standalone', undefined)).toBe('Standalone');
+  });
+
+  it('forces a clean remote provider session and waits for dom-ready before a switched-session send proceeds', async () => {
+    const domReadyAfter: Record<string, number> = { claude: 2, gemini: 0 };
+    const attemptsSeen: Record<string, number> = {};
+    const host: ProviderSessionResetHost = {
+      resetBootState: vi.fn(),
+      newSession: vi.fn().mockResolvedValue(undefined),
+      isDomReady: (provider) => {
+        attemptsSeen[provider] = (attemptsSeen[provider] ?? 0) + 1;
+        return attemptsSeen[provider] > domReadyAfter[provider];
+      },
+      wait: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await ensureFreshProviderSessions(['claude', 'gemini'], host);
+
+    // A stale remote thread from the previous local session must be discarded, not reused,
+    // before the switched-to session's own replay context is ever injected into it.
+    expect(host.resetBootState).toHaveBeenCalledWith('claude');
+    expect(host.resetBootState).toHaveBeenCalledWith('gemini');
+    expect(host.newSession).toHaveBeenCalledWith('claude');
+    expect(host.newSession).toHaveBeenCalledWith('gemini');
+    // Each provider is polled independently until its own bridge/dom reports ready.
+    expect(attemptsSeen.claude).toBeGreaterThan(domReadyAfter.claude);
+    expect(host.wait).toHaveBeenCalled();
+  });
+
+  it('gives up waiting for a provider that never reports dom-ready, without blocking the others', async () => {
+    const host: ProviderSessionResetHost = {
+      resetBootState: vi.fn(),
+      newSession: vi.fn().mockResolvedValue(undefined),
+      isDomReady: (provider) => provider === 'gemini',
+      wait: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await ensureFreshProviderSessions(['claude', 'gemini'], host, 3);
+
+    expect(host.wait).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/ui/conversationContinuity.ts
+++ b/src/ui/conversationContinuity.ts
@@ -45,6 +45,34 @@ export function buildConversationReplayContext(messages: readonly ReplayableConv
     : context.slice(context.length - MAX_REPLAY_CONTEXT_LENGTH);
 }
 
+export interface ProviderSessionResetHost {
+  resetBootState: (provider: AIProvider) => void;
+  newSession: (provider: AIProvider) => Promise<void>;
+  isDomReady: (provider: AIProvider) => boolean;
+  wait: () => Promise<void>;
+}
+
+// Desktop webviews keep a real, persistent remote conversation per provider (unlike the
+// website, which scopes each request to activeSessionId server-side). Switching local
+// conversation history does not touch that remote thread, so the first send after a
+// switch must force a clean provider session before any same-session replay context is
+// injected — otherwise two unrelated local sessions end up sharing one remote thread.
+export async function ensureFreshProviderSessions(
+  providers: readonly AIProvider[],
+  host: ProviderSessionResetHost,
+  maxWaitAttempts = 40,
+): Promise<void> {
+  await Promise.all(
+    providers.map(async (provider) => {
+      host.resetBootState(provider);
+      await host.newSession(provider);
+      for (let attempt = 0; attempt < maxWaitAttempts && !host.isDomReady(provider); attempt += 1) {
+        await host.wait();
+      }
+    }),
+  );
+}
+
 export function questionWithConversationContext(question: string, context?: string): string {
   const normalizedContext = context?.trim();
   if (!normalizedContext) return question;


### PR DESCRIPTION
## Problem

Switching to a conversation in the history sidebar caused every loaded provider webview to disconnect and reload, losing the live page state (and any logged-in chat context) just to display a locally stored transcript.

## Cause

`selectConversationSession` in `src/App.tsx` looped over all loaded providers calling `resetProviderBootState` + `host.provider.newSession()`, which navigates each webview to a fresh chat page — effectively a reconnect on every history switch.

## Fix

Remove the reset loop. Switching history now only swaps the local transcript, mode, and replay context; provider webviews keep their existing connection. The explicit "new conversation" action still resets providers as before, and the replay context is still injected on the next send.

## Verification

- `npm run typecheck` passes
- `npx vitest run` — 50 files, 377 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)