### PR TITLE
docs: prepare v1.5.1 maintenance release

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -10,16 +10,15 @@ Stelle eine Frage und lasse deine angemeldeten Web-Sitzungen von **ChatGPT, Clau
 
 > **Projektstatus:** Die Funktionsentwicklung ist abgeschlossen. Das letzte optionale Gedenk-Theme mit allen vier AI-Sister-Figuren ist enthalten; danach werden nur Anbieterkompatibilität, Sicherheit und Build-Probleme gepflegt. Die vorhandenen Snapshot-/Replay-Funktionen bleiben unverändert und werden nicht erweitert.
 
-## Neuerungen in v1.5.0
+## Neuerungen in v1.5.1
 
-- **Zuverlässigeres Senden an ChatGPT.** Wenn der Provider Enter verarbeitet und die Standardaktion verhindert, gilt dies nun als erfolgreicher Versand statt als fehlgeschlagene Eingabeinjektion.
-- **Sauber erfasste Antworten.** Prompt-Echos und offengelegte Workflow-Sprachanweisungen werden verworfen; bei mehreren Kandidaten zählt die neueste echte Provider-Antwort.
-- **Schnellere Navigation im Transkript.** Ein Klick auf einen Provider-Chip springt zur neuesten Antwort dieses Providers und hebt sie kurz hervor.
-- **Dauerhafte UI-Einstellung.** Der ein- oder ausgeklappte Zustand der Gesprächsseitenleiste bleibt nach einem Neustart erhalten.
-- **Stabile Verlaufsdaten.** Das bloße Öffnen einer unveränderten Sitzung ändert ihr Datum nicht mehr; Autorenbezeichnungen bleiben beim Speichern und Wiederherstellen erhalten.
-- **Strikte Sitzungstrennung.** Nach einem Verlaufswechsel wird weiterhin eine saubere Provider-Sitzung vorbereitet, bevor ein begrenzter Verlauf derselben Sitzung eingespielt wird. Fremder Remote-Chat-Kontext gelangt so nicht in die nächste Runde.
+- **Sicherheitsgeprüfte Runtime-Pfade.** Die Gemini-Statusprüfung verlangt nun den exakten Provider-Hostnamen; Gesprächs- und Nachrichten-IDs verwenden Web Crypto mit einer kollisionssicheren lokalen Rückfalllösung.
+- **Sichererer Windows-Source-Agent.** Das Agent-Ready Source Release akzeptiert nur die festen, shell-sicheren Tokens des Launchers und weist Shell-Sonderzeichen zurück.
+- **Bereinigte Entwicklungsabhängigkeiten.** Vitest und esbuild wurden aktualisiert, sodass alle behebbaren npm-Warnungen ohne Änderung des Funktionsumfangs entfernt sind.
+- **Gehärtete Release-Automatisierung.** JavaScript-basierte GitHub Actions nutzen Node-24-kompatible, auf unveränderliche Commits fixierte Versionen und minimale Workflow-Rechte.
+- **Kontinuierlicher Repository-Schutz.** Dependabot-Sicherheitsupdates, wöchentliche CodeQL-Analysen und geschützte `main`-Prüfungen sichern künftige Wartungsänderungen ab.
 
-Validierung und bekannte Plattformgrenzen stehen in den zweisprachigen [`v1.5.0 Release Notes`](./docs/RELEASE_NOTES_v1.5.0.md).
+Validierung, das dokumentierte GTK-Upstream-Risiko und bekannte Plattformgrenzen stehen in den zweisprachigen [`v1.5.1 Release Notes`](./docs/RELEASE_NOTES_v1.5.1.md).
 
 ## Edition wählen
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -10,16 +10,15 @@
 
 > **プロジェクト状況：** 機能開発は完了し、最後のオプションとして4人のAI-Sister記念Themeを追加しました。今後はprovider互換性、セキュリティ、build障害のみを保守します。既存のsnapshot／replayは現状のまま残し、拡張しません。
 
-## v1.5.0 の更新点
+## v1.5.1 の更新点
 
-- **ChatGPT送信の信頼性向上。** ProviderがEnterを受理して既定動作を止めた場合も送信成功として扱い、消えたpromptを注入失敗と誤判定しません。
-- **実際の回答だけを取得。** Promptの反響やworkflow用言語指示の露出を除外し、複数候補が描画された場合は最新の実回答を採用します。
-- **回答へ素早く移動。** AI接続chipを選ぶと、そのproviderの最新messageへ移動して短時間強調表示します。
-- **UI設定を保持。** 会話sidebarの開閉状態を再起動後も記憶します。
-- **履歴日時を安定化。** 内容が変わっていないsessionを開くだけでは日時を更新せず、author labelも保存・復元します。
-- **Session分離を維持。** 履歴切替後はcleanなprovider sessionを準備してから同一sessionの制限付き履歴を再生し、別のremote chat contextが次のturnへ混ざるのを防ぎます。
+- **Runtime経路をセキュリティ検査。** Geminiの状態判定はprovider hostnameの完全一致を要求し、会話とmessageのIDはWeb Cryptoと衝突しないローカルfallbackを使用します。
+- **Windows source agentを安全化。** Agent-Ready Source Releaseはlauncherに必要な固定のshell-safe tokenだけを受け付け、shellの特殊文字を拒否します。
+- **開発依存関係を整理。** Vitestとesbuildを更新し、既存機能を変えずに対応可能なnpm advisoryをすべて解消しました。
+- **Release automationを強化。** JavaScript製GitHub ActionsをNode 24対応版へ移行し、immutable commitへの固定と最小workflow権限を採用しました。
+- **継続的なrepo保護。** Dependabot security updates、週次CodeQL、保護された`main` checksが今後の保守変更を監視します。
 
-検証内容と既知のplatform制限は、日英併記の [`v1.5.0 release notes`](./docs/RELEASE_NOTES_v1.5.0.md) を参照してください。
+検証内容、記録済みのGTK上流リスク、既知のplatform制限は、日英併記の [`v1.5.1 release notes`](./docs/RELEASE_NOTES_v1.5.1.md) を参照してください。
 
 ## エディション
 

--- a/README.md
+++ b/README.md
@@ -10,16 +10,15 @@ Ask one question, then let your logged-in **ChatGPT, Claude, Gemini, and Grok** 
 
 > **Project status:** Feature development is complete. The final optional AI-Sister four-character commemorative theme is included; future changes are limited to provider compatibility, security, and build breakage. The shipped snapshot/replay tools remain available as-is but have no further roadmap.
 
-## v1.5.0 highlights
+## v1.5.1 highlights
 
-- **Reliable ChatGPT sends.** A provider-consumed Enter event is now treated as a successful send, preventing cleared prompts from being reported as injection failures.
-- **Cleaner captured answers.** Prompt echoes and leaked workflow language instructions are rejected, and the newest real provider answer wins when a page renders multiple candidates.
-- **Faster transcript navigation.** Selecting a provider connection chip jumps to and briefly highlights that provider's latest answer.
-- **Preferences that stay put.** The conversation sidebar remembers whether it was collapsed, including across restarts.
-- **Stable conversation history.** Merely reopening an unchanged session no longer changes its date, while author labels survive save and restore.
-- **Strict session isolation.** Switching history still prepares a clean provider session before bounded same-session replay, preventing unrelated remote chat context from leaking into the next turn.
+- **Security-scanned runtime paths.** Gemini status detection now requires the exact provider hostname, while conversation and message identities use Web Crypto with a collision-safe local fallback.
+- **Safer Windows source-agent launch.** Agent-Ready Source Release commands accept only the fixed shell-safe tokens required by the launcher and reject shell metacharacters.
+- **Clean development dependency graph.** Vitest and esbuild were upgraded to remove all actionable npm advisories without changing the application feature set.
+- **Hardened release automation.** JavaScript-based GitHub Actions use Node 24-compatible releases pinned to immutable commits with least-privilege workflow permissions.
+- **Continuous repository protection.** Dependabot security updates, weekly CodeQL analysis, and protected `main` checks now guard future maintenance work.
 
-See the bilingual [`v1.5.0 release notes`](./docs/RELEASE_NOTES_v1.5.0.md) for validation and known platform limits.
+See the bilingual [`v1.5.1 release notes`](./docs/RELEASE_NOTES_v1.5.1.md) for validation, the documented upstream GTK risk, and known platform limits.
 
 ## Choose the right edition
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -10,16 +10,15 @@
 
 > **專案狀態：** 功能開發已完成，最後一套可選的 AI-Sister 四角色同框紀念 Theme 已加入；之後僅維護 provider 相容性、安全問題與 build 失敗。現有 snapshot／replay 會原樣保留，但不再擴充。
 
-## v1.5.0 更新重點
+## v1.5.1 更新重點
 
-- **ChatGPT 送出更可靠。** Provider 已接收並攔截 Enter 時，現在會視為成功送出，不再把已清空的 prompt 誤報為注入失敗。
-- **擷取到真正的回答。** 會排除 prompt 回音與外洩的 workflow 語言指令；頁面同時出現多個候選回答時，以最新的真實回答為準。
-- **更快找到各家回答。** 點 AI 連線 chip 會跳到該 provider 最新一則訊息，並短暫醒目標示。
-- **介面偏好會記住。** 對話側邊欄的展開／收合狀態會跨重啟保留。
-- **對話歷史日期穩定。** 只開啟未變更的 session 不再更新日期，作者標籤也能完整保存與還原。
-- **維持嚴格 session 隔離。** 切換歷史後仍會先準備乾淨的 provider session，再有限度重播同一段對話，避免其他遠端聊天內容混入下一輪。
+- **Runtime 路徑通過安全掃描。** Gemini 狀態判斷改為精確比對 provider hostname；對話與訊息識別碼改用 Web Crypto，並保留不碰撞的本機備援。
+- **Windows source agent 啟動更安全。** Agent-Ready Source Release 只接受啟動器真正需要的固定安全 token，會拒絕 shell 特殊字元。
+- **開發依賴已清理。** 升級 Vitest 與 esbuild，排除所有可處理的 npm 安全警示，不改變既有 app 功能範圍。
+- **Release automation 更穩固。** JavaScript GitHub Actions 改用 Node 24 相容版本、固定 immutable commit，並採最小 workflow 權限。
+- **持續保護維護流程。** Dependabot security updates、每週 CodeQL 與受保護的 `main` checks 會守住後續維護變更。
 
-完整驗證與已知平台限制請見雙語版 [`v1.5.0 發布說明`](./docs/RELEASE_NOTES_v1.5.0.md)。
+完整驗證、已記錄的 GTK 上游風險與平台限制請見雙語版 [`v1.5.1 發布說明`](./docs/RELEASE_NOTES_v1.5.1.md)。
 
 ## 選擇適合的版本
 

--- a/docs/RELEASE_NOTES_v1.5.1.md
+++ b/docs/RELEASE_NOTES_v1.5.1.md
@@ -1,0 +1,57 @@
+# v1.5.1 — Security and release hardening
+
+## Stable maintenance release / 正式維護版本
+
+Multi-AI Chat Desktop `v1.5.1` is a focused security and maintenance release. It hardens Windows source-agent command execution, tightens Gemini hostname validation, replaces insecure identifier fallbacks, clears actionable development-dependency advisories, and upgrades the repository's release automation to Node 24-compatible actions. It adds no new product features and preserves the feature-frozen scope.
+
+Multi-AI Chat Desktop `v1.5.1` 是聚焦於安全與維護的版本。它強化 Windows source agent 的命令執行、收緊 Gemini hostname 驗證、替換不安全的識別碼備援、清除可處理的開發依賴警示，並把 release automation 升級到 Node 24 相容 Actions。本版不新增產品功能，維持 feature-frozen 範圍。
+
+## Runtime fixes / Runtime 修補
+
+- Windows Agent-Ready Source Release commands now pass through a strict allowlist of the fixed tokens required for `pnpm` or Corepack launch. Whitespace and shell metacharacters are rejected instead of being incompletely escaped.
+- Windows Agent-Ready Source Release 命令現在只允許 `pnpm`／Corepack 啟動真正需要的固定 token；空白與 shell 特殊字元會被拒絕，不再使用不完整的 escaping。
+- Gemini's blocked-state fallback requires the exact `gemini.google.com` hostname rather than accepting an arbitrary URL substring.
+- Gemini 的 blocked-state 備援改為精確比對 `gemini.google.com`，不再接受任意 URL substring。
+- Conversation and message identities use `crypto.randomUUID()` or `crypto.getRandomValues()` when available, with a process-local monotonic fallback rather than `Math.random()`.
+- 對話與訊息識別碼會優先使用 `crypto.randomUUID()`／`crypto.getRandomValues()`，並以 process-local 單調序列取代 `Math.random()` 備援。
+
+## Repository security / Repo 安全
+
+- Vitest is upgraded to `3.2.7` and esbuild to `0.25.12`, removing the six actionable npm Dependabot alerts discovered when repository scanning was enabled.
+- Vitest 升級到 `3.2.7`、esbuild 升級到 `0.25.12`，排除啟用掃描後找到的六筆可處理 npm Dependabot 警示。
+- GitHub Actions use Node 24-compatible releases pinned to immutable commits, checkout credentials are not persisted, and workflow permissions follow least privilege.
+- GitHub Actions 改用 Node 24 相容版本並固定 immutable commit；checkout 不保留 credentials，workflow 權限採 least privilege。
+- Dependabot security updates, monthly GitHub Actions update checks, weekly CodeQL analysis, and protected `main` status checks are enabled for future maintenance.
+- 已啟用 Dependabot security updates、每月 GitHub Actions 更新檢查、每週 CodeQL，以及受保護的 `main` status checks。
+
+## Accepted upstream risk / 已接受的上游風險
+
+- The Linux GTK3 dependency graph from the current Tauri `2.11.5` / Wry `0.55.1` stack still resolves to `glib 0.18.5`, which has a medium-severity advisory for `glib::VariantStrIter`.
+- 目前 Tauri `2.11.5`／Wry `0.55.1` 的 Linux GTK3 依賴仍會解析到 `glib 0.18.5`；其 `glib::VariantStrIter` 有一筆 medium advisory。
+- This application does not directly call that API, and `glib >=0.20` is not compatible with the upstream `gtk 0.18` graph. The alert is documented as a tolerable transitive risk until Tauri/Wry migrates upstream; it is not represented as fixed.
+- 本 app 未直接呼叫該 API，而 `glib >=0.20` 與上游 `gtk 0.18` dependency graph 不相容。此警示會以可接受的 transitive risk 留存，等待 Tauri/Wry 上游遷移，不會被宣稱為已修復。
+
+## Validation / 驗證
+
+- The release branch passed 384 frontend tests, 21 Agent contract tests, TypeScript type-checking, ESLint, adapter checks, npm audit, Rust tests, and warnings-denied Clippy on Windows, macOS, and Linux.
+- Release branch 通過 384 個前端測試、21 個 Agent contract 測試、TypeScript type-check、ESLint、adapter checks、npm audit、Rust tests，以及 Windows／macOS／Linux 的 warnings-denied Clippy。
+- CodeQL analysis passed for GitHub Actions, JavaScript/TypeScript, and Rust with no open code-scanning alerts on `main`.
+- CodeQL 的 GitHub Actions、JavaScript/TypeScript 與 Rust 分析全部通過，`main` 沒有 open code-scanning alert。
+- The immutable `v1.5.1` tag rebuilds the Windows installer and portable zip, Apple Silicon DMG, and Linux AppImage before this draft is published.
+- Immutable `v1.5.1` tag 會重新建置 Windows installer／portable zip、Apple Silicon DMG 與 Linux AppImage；draft 只有在這些產物成功後才會發布。
+
+## Downloads / 下載
+
+- Windows x64 installer and portable zip
+- Apple Silicon macOS DMG
+- Linux x86_64 AppImage
+
+## Notes / 注意事項
+
+- Windows artifacts remain unsigned and may trigger SmartScreen.
+- The macOS package is ad-hoc signed and signature-verified in CI, but is not Apple-notarized; follow the README first-launch steps if Gatekeeper blocks it.
+- Live macOS provider compatibility, especially Grok through Cloudflare verification, still depends on third-party behavior and has not been re-confirmed on a maintainer-owned Apple Silicon device for this patch.
+- Linux remains CI-packaged without a new real-device launch report.
+- Provider websites can change independently. Attach a sanitized exported debug log when reporting automation failures.
+
+**Full changelog:** https://github.com/teddashh/multi-ai-chat-desktop/compare/v1.5.0...v1.5.1


### PR DESCRIPTION
## Summary
- document the v1.5.1 security maintenance scope in English, Traditional Chinese, Japanese, and German
- add bilingual release notes covering runtime fixes, repository hardening, validation, and the accepted upstream GTK/glib risk
- keep repository development versions at 0.0.0; the immutable tag injects 1.5.1 during release builds

## Local release gate
- `pnpm verify` (384 frontend tests, 21 Agent tests, adapter checks, typecheck, lint)
- `pnpm audit` (0 known vulnerabilities)
- `cargo fmt -- --check`
- 52 Rust tests
- `cargo clippy --all-targets -- -D warnings`
- Agent launch dry-run reports zero writes