### PR TITLE
docs: prepare v1.6.0 release

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -10,15 +10,15 @@ Stelle eine Frage und lasse deine angemeldeten Web-Sitzungen von **ChatGPT, Clau
 
 > **Projektstatus:** Die Funktionsentwicklung ist abgeschlossen. Das letzte optionale Gedenk-Theme mit allen vier AI-Sister-Figuren und das schlanke Brainstorming-Preset sind enthalten. Das Preset nutzt die stabile freie Fan-out-Engine; danach werden nur Anbieterkompatibilität, Sicherheit und Build-Probleme gepflegt. Snapshot und Replay bleiben unverändert und werden nicht erweitert.
 
-## Neuerungen in v1.5.1
+## Neuerungen in v1.6.0
 
-- **Sicherheitsgeprüfte Runtime-Pfade.** Die Gemini-Statusprüfung verlangt nun den exakten Provider-Hostnamen; Gesprächs- und Nachrichten-IDs verwenden Web Crypto mit einer kollisionssicheren lokalen Rückfalllösung.
-- **Sichererer Windows-Source-Agent.** Das Agent-Ready Source Release akzeptiert nur die festen, shell-sicheren Tokens des Launchers und weist Shell-Sonderzeichen zurück.
-- **Bereinigte Entwicklungsabhängigkeiten.** Vitest und esbuild wurden aktualisiert, sodass alle behebbaren npm-Warnungen ohne Änderung des Funktionsumfangs entfernt sind.
-- **Gehärtete Release-Automatisierung.** JavaScript-basierte GitHub Actions nutzen Node-24-kompatible, auf unveränderliche Commits fixierte Versionen und minimale Workflow-Rechte.
-- **Kontinuierlicher Repository-Schutz.** Dependabot-Sicherheitsupdates, wöchentliche CodeQL-Analysen und geschützte `main`-Prüfungen sichern künftige Wartungsänderungen ab.
+- **Eigenes Brainstorming-Preset.** ChatGPT, Claude, Gemini und Grok untersuchen parallel ergänzende kreative Blickwinkel; alle verfügbaren Anbieter sind standardmäßig ausgewählt.
+- **Wiederherstellbare Ideenläufe.** Lokale Sitzungen, Snapshots, Replay und Markdown-Export bewahren die Brainstorming-Kennung und anbieterspezifischen Anweisungen.
+- **Barrierefreiheit bei großer Schrift.** Der Anbieter-Verbindungsbereich bleibt auch bei sehr großer Schrift oder niedrigen Fenstern durch Scrollen erreichbar.
+- **Ausrichtung des nativen WebViews.** Scrollbedingte Bounds-Updates werden pro Animationsframe gedrosselt, damit die aktive Seite ohne unnötige native Neupositionierung ausgerichtet bleibt.
+- **Stabiler Kernumfang.** Brainstorming nutzt den bewährten freien Fan-out-Graphen; die fünf eingefrorenen Workflow-Engines bleiben unverändert.
 
-Validierung, das dokumentierte GTK-Upstream-Risiko und bekannte Plattformgrenzen stehen in den zweisprachigen [`v1.5.1 Release Notes`](./docs/RELEASE_NOTES_v1.5.1.md).
+Validierung, Danksagung, das dokumentierte GTK-Upstream-Risiko und bekannte Plattformgrenzen stehen in den zweisprachigen [`v1.6.0 Release Notes`](./docs/RELEASE_NOTES_v1.6.0.md).
 
 ## Edition wählen
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -10,15 +10,15 @@
 
 > **プロジェクト状況：** 機能開発は完了し、最後のオプションとして4人のAI-Sister記念Themeと軽量なブレインストーミングpresetを追加しました。presetは安定した自由送信engineを再利用します。今後はprovider互換性、セキュリティ、build障害のみを保守し、既存のsnapshot／replayは拡張しません。
 
-## v1.5.1 の更新点
+## v1.6.0 の更新点
 
-- **Runtime経路をセキュリティ検査。** Geminiの状態判定はprovider hostnameの完全一致を要求し、会話とmessageのIDはWeb Cryptoと衝突しないローカルfallbackを使用します。
-- **Windows source agentを安全化。** Agent-Ready Source Releaseはlauncherに必要な固定のshell-safe tokenだけを受け付け、shellの特殊文字を拒否します。
-- **開発依存関係を整理。** Vitestとesbuildを更新し、既存機能を変えずに対応可能なnpm advisoryをすべて解消しました。
-- **Release automationを強化。** JavaScript製GitHub ActionsをNode 24対応版へ移行し、immutable commitへの固定と最小workflow権限を採用しました。
-- **継続的なrepo保護。** Dependabot security updates、週次CodeQL、保護された`main` checksが今後の保守変更を監視します。
+- **専用ブレインストーミングpreset。** ChatGPT、Claude、Gemini、Grokが相互補完的な創造的視点を並列に探索し、利用可能なproviderを初期状態ですべて選択します。
+- **復元可能な発想workflow。** ローカルsession、snapshot、replay、Markdown exportでBrainstormの種類とprovider固有の指示を保持します。
+- **大きな文字へのアクセシビリティ。** 文字を大幅に拡大した場合や高さの低いwindowでも、provider接続欄までscrollして操作できます。
+- **Native WebViewの位置合わせ。** scroll時のbounds更新をanimation frame単位に制限し、過剰なnative再配置を避けながら表示を揃えます。
+- **安定したcore scope。** Brainstormは実績のある自由送信fan-out graphを再利用し、凍結済みの5つのworkflow engineは変更しません。
 
-検証内容、記録済みのGTK上流リスク、既知のplatform制限は、日英併記の [`v1.5.1 release notes`](./docs/RELEASE_NOTES_v1.5.1.md) を参照してください。
+検証内容、contributorへの謝辞、記録済みのGTK上流リスク、既知のplatform制限は、日英併記の [`v1.6.0 release notes`](./docs/RELEASE_NOTES_v1.6.0.md) を参照してください。
 
 ## エディション
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Ask one question, then let your logged-in **ChatGPT, Claude, Gemini, and Grok** 
 
 > **Project status:** Feature development is complete. The final optional AI-Sister four-character commemorative theme and its lightweight Brainstorm preset are included; future changes are limited to provider compatibility, security, and build breakage. The preset reuses the stable Free fan-out engine, while the shipped snapshot/replay tools remain available as-is with no further roadmap.
 
-## v1.5.1 highlights
+## v1.6.0 highlights
 
-- **Security-scanned runtime paths.** Gemini status detection now requires the exact provider hostname, while conversation and message identities use Web Crypto with a collision-safe local fallback.
-- **Safer Windows source-agent launch.** Agent-Ready Source Release commands accept only the fixed shell-safe tokens required by the launcher and reject shell metacharacters.
-- **Clean development dependency graph.** Vitest and esbuild were upgraded to remove all actionable npm advisories without changing the application feature set.
-- **Hardened release automation.** JavaScript-based GitHub Actions use Node 24-compatible releases pinned to immutable commits with least-privilege workflow permissions.
-- **Continuous repository protection.** Dependabot security updates, weekly CodeQL analysis, and protected `main` checks now guard future maintenance work.
+- **Dedicated Brainstorm preset.** ChatGPT, Claude, Gemini, and Grok explore complementary creative lenses in parallel, with all available providers selected by default.
+- **Restorable ideation runs.** Local sessions, snapshots, replay, and Markdown export preserve the Brainstorm identity and its provider-specific instructions.
+- **Large-text accessibility.** The provider connection strip stays reachable at very large font sizes and in short windows instead of being pushed below the viewport.
+- **Native WebView alignment.** Scroll-driven bounds updates are animation-frame throttled so the focused provider page stays aligned without excessive native repositioning.
+- **Stable core scope.** Brainstorm reuses the proven Free fan-out graph; the five frozen workflow engines remain unchanged.
 
-See the bilingual [`v1.5.1 release notes`](./docs/RELEASE_NOTES_v1.5.1.md) for validation, the documented upstream GTK risk, and known platform limits.
+See the bilingual [`v1.6.0 release notes`](./docs/RELEASE_NOTES_v1.6.0.md) for validation, contributor credit, the documented upstream GTK risk, and known platform limits.
 
 ## Choose the right edition
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -10,15 +10,15 @@
 
 > **專案狀態：** 功能開發已完成，最後一套可選的 AI-Sister 四角色同框紀念 Theme 與輕量「腦力激盪」預設已加入；之後僅維護 provider 相容性、安全問題與 build 失敗。新預設沿用穩定的自由分送引擎，現有 snapshot／replay 會原樣保留且不再擴充。
 
-## v1.5.1 更新重點
+## v1.6.0 更新重點
 
-- **Runtime 路徑通過安全掃描。** Gemini 狀態判斷改為精確比對 provider hostname；對話與訊息識別碼改用 Web Crypto，並保留不碰撞的本機備援。
-- **Windows source agent 啟動更安全。** Agent-Ready Source Release 只接受啟動器真正需要的固定安全 token，會拒絕 shell 特殊字元。
-- **開發依賴已清理。** 升級 Vitest 與 esbuild，排除所有可處理的 npm 安全警示，不改變既有 app 功能範圍。
-- **Release automation 更穩固。** JavaScript GitHub Actions 改用 Node 24 相容版本、固定 immutable commit，並採最小 workflow 權限。
-- **持續保護維護流程。** Dependabot security updates、每週 CodeQL 與受保護的 `main` checks 會守住後續維護變更。
+- **專用腦力激盪預設。** ChatGPT、Claude、Gemini 與 Grok 會以互補的創意視角平行發想，預設選取所有可用 provider。
+- **可還原的發想流程。** 本機 session、snapshot、replay 與 Markdown 匯出都會保留 Brainstorm 身分及各 provider 的專屬指示。
+- **大字體無障礙改善。** 即使字體放得很大或視窗高度較短，provider 連線區仍可捲動到達，不會被推出可視範圍。
+- **原生 WebView 對齊。** 捲動造成的邊界更新改以 animation frame 節流，讓聚焦頁面保持對齊，同時避免過度重定位原生視窗。
+- **核心範圍維持穩定。** Brainstorm 沿用已驗證的自由分送 graph；既有五套凍結 workflow 引擎不變。
 
-完整驗證、已記錄的 GTK 上游風險與平台限制請見雙語版 [`v1.5.1 發布說明`](./docs/RELEASE_NOTES_v1.5.1.md)。
+完整驗證、貢獻者致謝、已記錄的 GTK 上游風險與平台限制，請見雙語版 [`v1.6.0 發布說明`](./docs/RELEASE_NOTES_v1.6.0.md)。
 
 ## 選擇適合的版本
 

--- a/docs/RELEASE_NOTES_v1.6.0.md
+++ b/docs/RELEASE_NOTES_v1.6.0.md
@@ -1,0 +1,70 @@
+# v1.6.0 — Brainstorm and accessibility
+
+## Stable feature release / 正式功能版本
+
+Multi-AI Chat Desktop `v1.6.0` completes the feature-frozen product with a dedicated Brainstorm preset and a focused large-text layout fix. Brainstorm is a sixth guided preset built on the proven Free fan-out graph, not a sixth workflow engine. The five stable engines and the local-first privacy model remain unchanged.
+
+Multi-AI Chat Desktop `v1.6.0` 以專用腦力激盪預設與聚焦的大字體版面修正，完成 feature-frozen 產品。Brainstorm 是建立在既有自由分送 fan-out graph 上的第六個引導預設，不是第六套 workflow 引擎；五套穩定引擎與 local-first 隱私模型皆維持不變。
+
+## Brainstorm preset / 腦力激盪預設
+
+- ChatGPT, Claude, Gemini, and Grok receive complementary creative lenses so parallel answers explore distinct directions instead of repeating the same generic prompt.
+- ChatGPT、Claude、Gemini 與 Grok 會收到互補的創意視角，讓平行回答探索不同方向，而不是重複同一份通用 prompt。
+- All four providers are selected by default; providers that are unavailable or not ready are still filtered by the existing sendability rules.
+- 預設選取四家 provider；無法使用或尚未就緒者仍會依既有 sendability 規則排除。
+- The preset identity and provider-specific instructions survive local session restore, snapshots, replay, and Markdown export.
+- 本機 session 還原、snapshot、replay 與 Markdown 匯出都會保留 preset 身分及 provider 專屬指示。
+- Existing Free-mode behavior remains unchanged because Brainstorm compiles to the same stable parallel graph with different prompt metadata.
+- 既有自由模式行為不變；Brainstorm 只是以不同 prompt metadata 編譯到同一套穩定平行 graph。
+
+## Accessibility and layout / 無障礙與版面
+
+- The provider connection strip remains reachable when users choose very large text or run the app in a short window.
+- 使用者採用超大字體或較矮視窗時，仍可捲動到 provider 連線區。
+- Native provider WebView bounds now follow scroll changes through a `requestAnimationFrame`-throttled update, preserving alignment without flooding native reposition calls.
+- 原生 provider WebView 的邊界會透過 `requestAnimationFrame` 節流更新跟隨捲動，保持對齊且不會大量觸發 native reposition。
+- Regression coverage protects both the reachable connection strip and the focused-WebView alignment behavior.
+- Regression tests 同時保護連線區可達性與聚焦 WebView 對齊行為。
+
+## Contributor thanks / 貢獻者致謝
+
+Thanks to Dave Tseng ([`@DaveTseng2019`](https://github.com/DaveTseng2019)) for reporting and implementing the large-font connection-strip fix in [PR #25](https://github.com/teddashh/multi-ai-chat-desktop/pull/25), including the WebView synchronization improvement and regression tests.
+
+感謝 Dave Tseng（[`@DaveTseng2019`](https://github.com/DaveTseng2019)）在 [PR #25](https://github.com/teddashh/multi-ai-chat-desktop/pull/25) 回報並實作大字體連線區修正，也一併改善 WebView 同步並補上 regression tests。
+
+## Validation / 驗證
+
+- The release branch passes 394 frontend tests, 21 Agent contract tests, TypeScript type-checking, ESLint, adapter checks, npm audit, 52 Rust tests, and warnings-denied Clippy.
+- Release branch 通過 394 個 frontend tests、21 個 Agent contract tests、TypeScript type-check、ESLint、adapter checks、npm audit、52 個 Rust tests，以及 warnings-denied Clippy。
+- Pull-request CI validates warnings-denied Clippy on Windows, macOS, and Linux before the release tag is created.
+- 建立 release tag 前，pull-request CI 會在 Windows、macOS 與 Linux 驗證 warnings-denied Clippy。
+- The immutable `v1.6.0` tag rebuilds the Windows installer and portable zip, Apple Silicon DMG, and Linux AppImage before the release is published.
+- Immutable `v1.6.0` tag 會重新建置 Windows installer／portable zip、Apple Silicon DMG 與 Linux AppImage；全部產物完成後才發布正式版本。
+
+## Accepted upstream risk / 已接受的上游風險
+
+- The current Tauri/Wry Linux GTK3 dependency graph retains the previously documented medium-severity `glib::VariantStrIter` advisory.
+- 目前 Tauri／Wry 的 Linux GTK3 dependency graph 仍保留先前記錄的 medium-severity `glib::VariantStrIter` advisory。
+- This app does not directly call the affected API, and the compatible upstream GTK graph does not yet provide the newer `glib` line. The transitive risk remains documented rather than being represented as fixed.
+- 本 app 未直接呼叫受影響 API，而相容的上游 GTK graph 尚未提供新版 `glib`；因此繼續如實記錄此 transitive risk，不會宣稱已修復。
+
+## Downloads / 下載
+
+- Windows x64 installer and portable zip
+- Apple Silicon macOS DMG
+- Linux x86_64 AppImage
+
+## Notes / 注意事項
+
+- Windows artifacts remain unsigned and may trigger SmartScreen.
+- Windows 產物仍未簽章，可能觸發 SmartScreen。
+- The macOS package is ad-hoc signed and signature-verified in CI, but is not Apple-notarized; follow the README first-launch steps if Gatekeeper blocks it.
+- macOS package 使用 ad-hoc 簽章並由 CI 驗證，但尚未 Apple notarize；若 Gatekeeper 阻擋，請依 README 的首次啟動步驟操作。
+- Grok login and Cloudflare verification remain third-party behavior and may vary by network, account, or provider changes.
+- Grok 登入與 Cloudflare 驗證屬第三方行為，可能因網路、帳號或 provider 改版而異。
+- Linux remains CI-packaged without a new maintainer-owned real-device launch report.
+- Linux 仍由 CI 封裝，本版沒有 maintainer 自有實機的最新啟動回報。
+- Provider websites can change independently. Attach a sanitized exported debug log when reporting automation failures.
+- Provider 網頁可能獨立改版；回報自動化失敗時，請附上已去識別化的匯出 debug log。
+
+**Full changelog:** https://github.com/teddashh/multi-ai-chat-desktop/compare/v1.5.1...v1.6.0


### PR DESCRIPTION
## Summary

- document the new Brainstorm preset in English, Traditional Chinese, Japanese, and German
- publish bilingual v1.6.0 release notes with compatibility limits and validation results
- credit Dave Tseng for the large-font connection-strip and WebView alignment fix

## Why

v1.6.0 completes the feature-frozen desktop edition with its sixth guided preset while preserving the five stable workflow engines. It also includes the large-text accessibility fix merged in PR #25.

## Validation

- `pnpm verify` — 394 frontend tests and 21 Agent contract tests
- `pnpm build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 52 tests
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `pnpm audit` — no known vulnerabilities
- `node scripts/agent/launch.mjs --dry-run --json`