### PR TITLE
fix: skip creating empty conversation on repeated New Conversation click

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1460,6 +1460,15 @@ export default function App() {
   const startNewConversation = useCallback(() => {
     if (isProcessing) return;
     const now = Date.now();
+    if (conversationMessages(messages).length === 0) {
+      setSessions((current) => {
+        const existing = current.find((session) => session.id === activeSessionId);
+        if (!existing) return current;
+        const next = upsertConversationSession(current, { ...existing, updatedAt: now });
+        return persistConversationSessions(next);
+      });
+      return;
+    }
     const nextSession = createConversationSession({ now });
     setSessions((current) => {
       const existing = current.find((session) => session.id === activeSessionId);


### PR DESCRIPTION
## Problem
Clicking "New Conversation" while the currently active conversation is already empty (no messages) still created and switched to a brand-new blank session, leaving a duplicate empty entry piling up in the sidebar history.

## Cause
`startNewConversation` in `src/App.tsx` unconditionally allocated a new `ConversationSession` and made it active, regardless of whether the current conversation already had zero messages.

## Fix
Added an early branch: if the current conversation has no messages, skip creating a new session entirely — just bump the existing empty session's `updatedAt` (so its sidebar timestamp still reflects the click) and return.

## Verification
- `npm run typecheck` — passes
- `npx vitest run` — 51 files / 394 tests passing
- Manually launched the Tauri dev app and confirmed in the running window: clicking New Conversation on an empty conversation no longer adds a duplicate blank sidebar entry, and its timestamp updates; clicking it with existing content still creates a fresh conversation as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)