### PR TITLE
fix: skip consult reviewer step when both first-round AIs are not ready

### DIFF
--- a/src/workflow/graph/consultGraph.ts
+++ b/src/workflow/graph/consultGraph.ts
@@ -1,5 +1,18 @@
 import { DEFAULT_CONSULT_ROLES } from '../../../shared/constants';
-import type { WorkflowGraph } from './types';
+import { SKIP_RESPONSE } from '../state';
+import type { NodeId, TextCondition, WorkflowGraph } from './types';
+
+const ERROR_RESPONSE_PATTERN = '^\\[Error:\\s*[\\s\\S]*?\\]$';
+
+function notReady(node: NodeId): TextCondition {
+  return {
+    type: 'any',
+    conditions: [
+      { type: 'regex', ref: { kind: 'output', node }, pattern: ERROR_RESPONSE_PATTERN },
+      { type: 'equals', left: { kind: 'output', node }, right: { kind: 'literal', text: SKIP_RESPONSE } },
+    ],
+  };
+}
 
 export const consultGraph: WorkflowGraph = {
   schemaVersion: 1,
@@ -95,8 +108,11 @@ export const consultGraph: WorkflowGraph = {
     },
   },
   edges: [
-    { from: 'first', to: 'reviewer' },
-    { from: 'second', to: 'reviewer' },
+    {
+      from: ['first', 'second'],
+      to: 'reviewer',
+      when: { type: 'not', condition: { type: 'all', conditions: [notReady('first'), notReady('second')] } },
+    },
     { from: 'reviewer', to: 'summary' },
   ],
   onComplete: { status: '' },


### PR DESCRIPTION
## Problem
In the 多方諮詢 (consult) workflow, the reviewer step always ran after the two first-round AIs (first/second) finished — even when **both** came back as adapter errors (e.g. `[Error: adapter not installed]`) or a user-chosen skip. The reviewer would then be asked to review two error strings, and the workflow would still produce a review/summary from nothing.

## Cause
`consultGraph.ts` wired `first -> reviewer` and `second -> reviewer` as two unconditional edges. The executor only requires each edge's source node to be *completed* (not *successful*) before continuing, so an all-failed first round still unlocked the reviewer step.

## Fix
Merged the two edges into a single conditional edge `[first, second] -> reviewer` that only fires when at least one of the two responses is not an error/skip. If both are not ready, the workflow ends right after showing their outputs, instead of entering the reviewer/summary steps.

## Verification
- `npm run typecheck` — clean
- `npx vitest run` — 51 files / 396 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)