### PR TITLE
fix: keep long-running tasks alive while provider reports thinking

### DIFF
--- a/src/__tests__/pull.test.ts
+++ b/src/__tests__/pull.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../../injected/bootstrap';
 import { onBridgeMessage } from '../bridge/bus';
 import {
+  AWAITING_MAX_MS,
   handleTitleMessage,
   parsePullResult,
   pullProvider,
@@ -190,6 +191,30 @@ describe('pull transport', () => {
     cleanup();
     expect(vi.mocked(host.provider.evalWithCallback).mock.calls.length).toBeGreaterThan(callsBeforeWatchdog);
     expect(messages.some((msg) => msg.transport === 'local' && msg.action === 'RESPONSE_DONE' && msg.payload === '[Error: bridge degraded]')).toBe(true);
+  });
+
+  it('keeps waiting past the awaiting cap while status reports thinking, then degrades once thinking stops', async () => {
+    vi.useFakeTimers();
+    const { messages, cleanup } = collectMessages();
+    setProviderAwaiting(provider, true);
+    vi.mocked(host.provider.evalWithCallback).mockResolvedValue(JSON.stringify([]));
+
+    await vi.advanceTimersByTimeAsync(AWAITING_MAX_MS - 1_000);
+    handleTitleMessage({
+      v: 1,
+      action: 'STATUS_REPORT',
+      provider,
+      bootId: 'long-task',
+      seq: 1,
+      payload: { dom: 'ready', thinking: true },
+      transport: 'title',
+    });
+    await vi.advanceTimersByTimeAsync(AWAITING_MAX_MS - 1_000);
+    expect(messages.some((msg) => msg.transport === 'local' && msg.payload === '[Error: bridge degraded]')).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    cleanup();
+    expect(messages.some((msg) => msg.transport === 'local' && msg.payload === '[Error: bridge degraded]')).toBe(true);
   });
 
   it('runs a distinct forced pull after an in-flight non-forced pull while still pending', async () => {

--- a/src/__tests__/workflow.test.ts
+++ b/src/__tests__/workflow.test.ts
@@ -10,7 +10,7 @@ import {
   PROMPTS,
 } from '../../shared/constants';
 import { onBridgeMessage, publishBridgeMessage, resetBusForTests } from '../bridge/bus';
-import { AWAITING_MAX_MS, pullProvider, resetBridgePullForTests } from '../bridge/pull';
+import { AWAITING_MAX_MS, handleTitleMessage, pullProvider, resetBridgePullForTests } from '../bridge/pull';
 import { host } from '../host';
 import { getInFlightProviders, resetCancelState } from '../workflow/cancel';
 import { hasPendingCheckpoint, onCheckpoint, resetCheckpointForTests, resolveCheckpoint, type PendingCheckpoint } from '../workflow/checkpoint';
@@ -159,6 +159,38 @@ describe('workflow engine', () => {
     await vi.advanceTimersByTimeAsync(AWAITING_MAX_MS + 500);
     await expect(promise).resolves.toEqual({ response: '[Error: bridge degraded]', turn: 1 });
     await vi.advanceTimersByTimeAsync(STEP_TIMEOUT_MS + 1);
+  });
+
+  it('thinking status reports keep a long task alive past both timeout caps', async () => {
+    const promise = sendAndWait('claude', 'long review task');
+    await Promise.resolve();
+
+    await vi.advanceTimersByTimeAsync(AWAITING_MAX_MS - 1_000);
+    handleTitleMessage({
+      v: 1,
+      action: 'STATUS_REPORT',
+      provider: 'claude',
+      bootId: 'long-task',
+      seq: 1,
+      payload: { dom: 'ready', thinking: true },
+      transport: 'title',
+    });
+    await vi.advanceTimersByTimeAsync(AWAITING_MAX_MS - 1_000);
+
+    let settled = false;
+    void promise.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    publishBridgeMessage(done('claude', 'reviewed'));
+    await expect(promise).resolves.toEqual({ response: 'reviewed', turn: 1 });
   });
 
   it('keeps polling armed after a pulled chunk', async () => {

--- a/src/bridge/pull.ts
+++ b/src/bridge/pull.ts
@@ -60,7 +60,11 @@ export function handleTitleMessage(message: BridgeMessage): void {
   }
   publish(message);
   if (!message.provider) return;
-  const payload = message.payload as { bulkReady?: number; doneReady?: boolean } | undefined;
+  const payload = message.payload as { bulkReady?: number; doneReady?: boolean; thinking?: boolean } | undefined;
+  // A provider still visibly generating must not hit the awaiting cap mid-task.
+  if (payload?.thinking === true && pending.has(message.provider)) {
+    awaitingSince.set(message.provider, Date.now());
+  }
   if (typeof payload?.bulkReady === 'number' && payload.bulkReady > 0) {
     void pullProvider(message.provider);
     if (payload.doneReady === true) armDoneWatchdog(message.provider);

--- a/src/workflow/waitForResponse.ts
+++ b/src/workflow/waitForResponse.ts
@@ -12,7 +12,7 @@ interface Waiter {
   resolve: (value: string) => void;
   reject: (reason: Error) => void;
   settled: boolean;
-  timer: ReturnType<typeof globalThis.setTimeout>;
+  timer: ReturnType<typeof globalThis.setTimeout> | undefined;
 }
 
 const waiters = new Map<string, Waiter>();
@@ -29,9 +29,15 @@ export function ensureWorkflowBusSubscription(): void {
 }
 
 function handleBridgeMessage(message: BridgeMessage): void {
+  if (!message.provider) return;
+  if (message.action === 'STATUS_REPORT') {
+    // A provider still visibly generating must not hit the engine timeout mid-task.
+    const payload = message.payload as { thinking?: boolean } | undefined;
+    if (payload?.thinking === true) rearmProviderTimers(message.provider);
+    return;
+  }
   if (message.action !== 'RESPONSE_DONE') return;
   if (message.transport !== 'pull' && message.transport !== 'local') return;
-  if (!message.provider) return;
   for (const waiter of [...waiters.values()]) {
     if (waiter.provider !== message.provider) continue;
     settle(waiter, 'resolve', payloadText(message.payload));
@@ -52,19 +58,25 @@ export function waitForResponse(provider: AIProvider, turn: number): Promise<str
   ensureWorkflowBusSubscription();
   rejectExistingProviderWaiters(provider, new Error('superseded by a newer send'));
   return new Promise((resolve, reject) => {
-    const waiter: Waiter = {
-      provider,
-      turn,
-      resolve,
-      reject,
-      settled: false,
-      timer: globalThis.setTimeout(() => {
-        const providerName = AI_PROVIDERS[provider]?.name ?? provider;
-        settle(waiter, 'reject', new Error(`${providerName} response timed out after ${STEP_TIMEOUT_MS / 1000}s`));
-      }, STEP_TIMEOUT_MS),
-    };
+    const waiter: Waiter = { provider, turn, resolve, reject, settled: false, timer: undefined };
+    armTimeout(waiter);
     waiters.set(key(provider, turn), waiter);
   });
+}
+
+function armTimeout(waiter: Waiter): void {
+  waiter.timer = globalThis.setTimeout(() => {
+    const providerName = AI_PROVIDERS[waiter.provider]?.name ?? waiter.provider;
+    settle(waiter, 'reject', new Error(`${providerName} response timed out after ${STEP_TIMEOUT_MS / 1000}s`));
+  }, STEP_TIMEOUT_MS);
+}
+
+function rearmProviderTimers(provider: AIProvider): void {
+  for (const waiter of waiters.values()) {
+    if (waiter.provider !== provider || waiter.settled) continue;
+    globalThis.clearTimeout(waiter.timer);
+    armTimeout(waiter);
+  }
 }
 
 function rejectExistingProviderWaiters(provider: AIProvider, reason: Error): void {


### PR DESCRIPTION
## Problem

In consult mode, when Claude is the reviewer and runs a long task (deep thinking / research) past ~10 minutes, its step is force-completed with `[Error: bridge degraded]` even though the page is still visibly generating, and the summary step then integrates the error text instead of the real review.

## Cause

Both timeout layers are fixed total-duration caps, blind to provider activity:

- `AWAITING_MAX_MS` (600s) in `src/bridge/pull.ts` synthesizes a degraded `RESPONSE_DONE` once the total wait exceeds the cap.
- `STEP_TIMEOUT_MS` (630s) in `src/workflow/waitForResponse.ts` rejects the waiter on the same fixed clock.

The injected engine reports `thinking: true` via STATUS_REPORT every `statusIntervalMs`, but neither timer consulted it. The `reviewer → summary` edge is unconditional, so the error flowed straight into the final integration.

## Fix

Turn both caps into inactivity timeouts. A STATUS_REPORT with `thinking: true` for a pending provider now:

- refreshes `awaitingSince` in `bridge/pull.ts`, and
- re-arms the waiter timer in `workflow/waitForResponse.ts`.

The workflow now waits for the task to actually finish before the summary step runs. A provider that truly stalls (stops reporting thinking) still degrades after the same 10-minute window, so the safety net is unchanged.

## Verification

- `npm run typecheck` — clean
- `npx vitest run` — 51 files, 408 tests passed, including two new tests:
  - pull: thinking status reports keep the wait alive past `AWAITING_MAX_MS`, and it still degrades once thinking stops
  - workflow: a long task survives both timeout caps while thinking and resolves with the real final response

🤖 Generated with [Claude Code](https://claude.com/claude-code)