### PR TITLE
release: v1.6.2 complete Brainstorm and provider resilience

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -10,15 +10,15 @@ Stelle eine Frage und lasse deine angemeldeten Web-Sitzungen von **ChatGPT, Clau
 
 > **Projektstatus:** Die Funktionsentwicklung ist abgeschlossen. Das letzte optionale Gedenk-Theme mit allen vier AI-Sister-Figuren und das Brainstorming-Preset mit 12 Runden sind enthalten. In jeder Runde antworten alle vier Anbieter einmal: insgesamt 48 Beiträge mit wechselnder Reihenfolge und vollständigem Verlauf derselben Sitzung. Danach werden nur Anbieterkompatibilität, Sicherheit und Build-Probleme gepflegt; Snapshot und Replay bleiben unverändert.
 
-## Neuerungen in v1.6.1
+## Neuerungen in v1.6.2
 
-- **Vollständig lokalisierter Workflow-Fortschritt.** Modusstatus, Runden und Phasen, Rollenbezeichnungen, Prozessverlauf und Replay folgen English, 繁體中文, 日本語 oder Deutsch, ohne chinesische Texte in einer anderssprachigen Oberfläche.
-- **Verifizierte Gesprächsgrenzen.** Beim Öffnen lokaler Verläufe bleiben Anbieterseiten verbunden. Vor der ersten Folgefrage startet die App jedoch einen sauberen Remote-Thread und prüft den neuen WebView-Boot, bevor Kontext derselben Sitzung gesendet wird. Schlägt der Reset fehl, wird nichts gesendet und der Entwurf bleibt erhalten.
-- **Vorhersehbarer neuer Chat.** Wiederholtes Klicken in einer leeren Sitzung erzeugt keine Duplikate; Modus, Preset, Transkriptzustand und der nächste Remote-Versand werden trotzdem vollständig zurückgesetzt.
-- **Robuster Beratungsmodus.** Liefern beide ersten KIs nur Fehler oder übersprungene Antworten, endet der Ablauf, statt unbrauchbaren Text prüfen zu lassen. Eine einzige brauchbare Antwort reicht weiterhin für Prüfung und Zusammenfassung.
-- **Contributor-Fixes vollständig integriert.** Die ursprüngliche Autorenschaft von Dave Tsengs PRs #23, #31 und #32 bleibt erhalten; ergänzt wurden Boot-Gate, Graph-Versionierung, Lokalisierung und Regressionstests.
+- **Vollständiger Brainstorm-Workflow.** Alle vier Anbieter antworten in jeder der 12 Runden einmal: insgesamt 48 Beiträge, mit wechselnder Reihenfolge, vollständigem Kontext derselben Sitzung und fünf Phasen vom Problemrahmen bis zu testbaren Konzepten.
+- **Keepalive für lange Aufgaben.** Thinking-Status, Stream-Chunks, Bulk-Antworten, Abschlusssignale und ein neuer Document-Boot erneuern das Inaktivitätsfenster. Eine separate 60-Minuten-Grenze verhindert endloses Warten auf veraltete Anbieterzustände.
+- **Sichererer Provider-Einstieg.** Claude-Login und Google-SSO-Erkennung sind aktualisiert. Bei Cloudflare oder hCaptcha wartet die Bridge, ohne Sicherheitsprüfungen des Anbieters zu umgehen.
+- **Robuster Grok-Challenge-Ablauf.** Automation startet erst nach Abschluss des Challenge-Frames; Grok-Seiten erhalten keinen History-API-Monkey-Patch mehr, der den Login stören könnte.
+- **Contributor-Fix vollständig integriert.** Dave Tsengs Ursachenanalyse aus PR #34 bleibt als Co-Autor erhalten und wurde um alle Aktivitätssignale, eine absolute Zeitgrenze und Regressionstests ergänzt.
 
-Validierung, Danksagung, das dokumentierte GTK-Upstream-Risiko und bekannte Plattformgrenzen stehen in den zweisprachigen [`v1.6.1 Release Notes`](./docs/RELEASE_NOTES_v1.6.1.md).
+Validierung, Danksagung, das dokumentierte GTK-Upstream-Risiko und bekannte Plattformgrenzen stehen in den zweisprachigen [`v1.6.2 Release Notes`](./docs/RELEASE_NOTES_v1.6.2.md).
 
 ## Edition wählen
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -10,15 +10,15 @@
 
 > **プロジェクト状況：** 機能開発は完了し、最後のオプションとして4人のAI-Sister記念Themeと12ラウンドのブレインストーミングpresetを追加しました。各ラウンドで4つのproviderが1回ずつ回答し、合計48発言になります。発言順をラウンドごとに交代し、同一sessionの全履歴を引き継ぎます。今後はprovider互換性、セキュリティ、build障害のみを保守し、既存のsnapshot／replayは拡張しません。
 
-## v1.6.1 の更新点
+## v1.6.2 の更新点
 
-- **Workflow進行表示を完全にローカライズ。** mode status、round／phase、role label、process trace、ReplayがEnglish、繁體中文、日本語、Deutschに従い、別言語のUIへ中国語ラベルが混ざりません。
-- **検証済みの会話境界。** ローカル履歴へ切り替えてもproviderページの接続は維持しますが、最初の追質問前に新しいremote threadを作り、WebViewの新しいbootを確認してから同一sessionのcontextを送ります。Resetに失敗した場合は何も送信せず、draftを再試行用に残します。
-- **予測可能な「新しい会話」。** 空の会話で繰り返し押しても重複sessionを作らず、mode、preset、transcript状態、次回のremote送信は完全にリセットします。
-- **Consultの障害耐性。** 最初の2 AIがerrorまたはskipだけを返した場合、無効な文章をreviewさせず停止します。少なくとも1件が有効ならreviewとsummaryを続行します。
-- **Contributor修正を完全統合。** Dave TsengのPR #23、#31、#32は元のauthor commitを保持し、maintainerがboot gate、graph version、localization、regression coverageを補完しました。
+- **完全なBrainstorm workflow。** 12ラウンドすべてで4 providerが1回ずつ回答し、合計48発言になります。順番を毎ラウンド交代し、同一sessionの全contextと、課題設定から検証可能なconceptまでの5段階を使用します。
+- **長時間taskのkeepalive。** thinking、stream chunk、bulk response、完了signal、新しいdocument bootがinactivity windowを更新します。別の60分hard capにより、古いprovider状態で永久に待機しません。
+- **より安全なprovider entry。** Claude loginとGoogle SSO検出を更新し、CloudflareまたはhCaptchaではbridge開始を延期します。providerのsecurity checkを迂回しません。
+- **Grok challengeへの耐性。** challenge frameが完了するまでautomationを開始せず、loginを妨げる可能性のあるHistory API monkey-patchをGrokページへ適用しません。
+- **Contributor修正を完全統合。** Dave TsengがPR #34で特定したroot causeをco-authorとして保持し、全activity signal、absolute timeout、regression coverageを追加しました。
 
-検証内容、contributorへの謝辞、記録済みのGTK上流リスク、既知のplatform制限は、日英併記の [`v1.6.1 release notes`](./docs/RELEASE_NOTES_v1.6.1.md) を参照してください。
+検証内容、contributorへの謝辞、記録済みのGTK上流リスク、既知のplatform制限は、日英併記の [`v1.6.2 release notes`](./docs/RELEASE_NOTES_v1.6.2.md) を参照してください。
 
 ## エディション
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Ask one question, then let your logged-in **ChatGPT, Claude, Gemini, and Grok** 
 
 > **Project status:** Feature development is complete. The final optional AI-Sister four-character commemorative theme and its 12-round Brainstorm preset are included; future changes are limited to provider compatibility, security, and build breakage. Every Brainstorm round includes all four providers—48 contributions total—with a rotating speaking order and full same-session history. The shipped snapshot/replay tools remain available as-is with no further roadmap.
 
-## v1.6.1 highlights
+## v1.6.2 highlights
 
-- **Fully localized workflow progress.** Mode status, round/phase text, role labels, process traces, and Replay now follow English, Traditional Chinese, Japanese, or German without leaking Chinese labels into another UI language.
-- **Verified conversation boundaries.** Reopening local history keeps provider pages connected, but the first follow-up starts a clean remote thread and verifies the new WebView boot before any same-session context is sent. A failed reset sends nothing and leaves the draft available for retry.
-- **Predictable New conversation.** Repeated clicks reuse the current blank session instead of creating duplicates, while still resetting mode, preset, transcript state, and the next remote send.
-- **Resilient Consult mode.** When both initial AIs return only errors or skips, Consult stops instead of asking another AI to review unusable text; one usable initial answer still continues through review and summary.
-- **Contributor-integrated maintenance.** Dave Tseng’s PRs #23, #31, and #32 are preserved with original authorship and completed with maintainer boot-gating, graph-versioning, localization, and regression coverage.
+- **The complete Brainstorm workflow.** All four providers now contribute in each of 12 rounds—48 responses total—with rotating order, full same-session context, and five phases from framing through testable concepts.
+- **Long-task keepalive.** Thinking state, streamed chunks, bulk responses, completion signals, and a new document boot all refresh the inactivity window; a separate 60-minute cap prevents stale provider state from waiting forever.
+- **Safer provider entry.** Claude login and Google SSO detection are current, while Cloudflare or hCaptcha pages defer bridge startup without attempting to bypass provider security checks.
+- **Grok challenge resilience.** Challenge frames are allowed to complete before automation starts, and Grok pages no longer receive History API monkey-patching that could interfere with login.
+- **Contributor-integrated maintenance.** Dave Tseng’s root-cause fix from PR #34 is preserved through co-authorship and extended with activity-complete timeout semantics and regression coverage.
 
-See the bilingual [`v1.6.1 release notes`](./docs/RELEASE_NOTES_v1.6.1.md) for validation, contributor credit, the documented upstream GTK risk, and known platform limits.
+See the bilingual [`v1.6.2 release notes`](./docs/RELEASE_NOTES_v1.6.2.md) for validation, contributor credit, the documented upstream GTK risk, and known platform limits.
 
 ## Choose the right edition
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -10,15 +10,15 @@
 
 > **專案狀態：** 功能開發已完成，最後一套可選的 AI-Sister 四角色同框紀念 Theme 與 12 輪「腦力激盪」預設已加入；之後僅維護 provider 相容性、安全問題與 build 失敗。腦力激盪的每一輪都由四家各回答一次，共 48 次發言，並輪換發言順序、保留同一 session 的完整前文；現有 snapshot／replay 會原樣保留且不再擴充。
 
-## v1.6.1 更新重點
+## v1.6.2 更新重點
 
-- **Workflow 進度完整在地化。** 模式狀態、輪次／階段、角色名稱、流程追蹤與 Replay 都會跟隨 English、繁體中文、日本語或 Deutsch，不再於英文介面混入「第一輪」等中文標籤。
-- **可驗證的對話邊界。** 開啟本機歷史記錄時會保留 provider 頁面連線；第一次追問前才建立乾淨的遠端 thread，並確認 WebView 已切到新的 boot，才送入同一 session 的上下文。Reset 失敗時不會送出任何內容，草稿也會保留供重試。
-- **可預期的新對話。** 連按「新對話」會沿用目前的空白 session，不再製造重複項目；模式、preset、逐字稿狀態與下一次遠端送出仍會完整重設。
-- **Consult 容錯改善。** 兩個首輪 AI 都只回傳錯誤或略過時，流程會直接停止，不再要求第三家審查無效文字；只要仍有一份可用回答，就會照常進入審查與總結。
-- **完整整合貢獻者修正。** Dave Tseng 的 PR #23、#31、#32 均保留原作者 commit，並由 maintainer 補上 boot gate、graph version、語系與 regression coverage。
+- **完整腦力激盪流程。** 四家 AI 在 12 輪中每輪各回答一次，共 48 次發言；順序逐輪輪換、沿用同一 session 的完整前文，並依問題框定至可測試概念分成五個階段。
+- **長任務 keepalive。** 思考狀態、串流片段、批次回答、完成訊號與新的 document boot 都會刷新 inactivity window；另設 60 分鐘硬上限，避免過期 provider 狀態造成永久等待。
+- **更安全的 provider 入口。** Claude 登入與 Google SSO 偵測已更新；遇到 Cloudflare 或 hCaptcha 時會延後 bridge 啟動，不會嘗試繞過 provider 的安全驗證。
+- **Grok 驗證韌性。** 安全驗證 frame 完成前不啟動自動化，且不再對 Grok 頁面 monkey-patch History API，避免干擾登入流程。
+- **完整整合貢獻者修正。** Dave Tseng 在 PR #34 找到的 root cause 以共同作者保留，並補齊所有活動訊號、絕對逾時與 regression coverage。
 
-完整驗證、貢獻者致謝、已記錄的 GTK 上游風險與平台限制，請見雙語版 [`v1.6.1 發布說明`](./docs/RELEASE_NOTES_v1.6.1.md)。
+完整驗證、貢獻者致謝、已記錄的 GTK 上游風險與平台限制，請見雙語版 [`v1.6.2 發布說明`](./docs/RELEASE_NOTES_v1.6.2.md)。
 
 ## 選擇適合的版本
 

--- a/docs/RELEASE_NOTES_v1.6.2.md
+++ b/docs/RELEASE_NOTES_v1.6.2.md
@@ -1,0 +1,79 @@
+# v1.6.2 — Complete Brainstorm and provider resilience
+
+## Stable maintenance release / 正式維護版本
+
+Multi-AI Chat Desktop `v1.6.2` completes the intended 12-round Brainstorm design, makes long provider responses activity-aware, and hardens Claude and Grok entry around current login and challenge pages. It remains within the frozen scope: this release corrects and stabilizes shipped workflows rather than adding a new product surface.
+
+Multi-AI Chat Desktop `v1.6.2` 完成原定的 12 輪腦力激盪設計、讓 provider 長回覆能依活動狀態延長等待，並針對目前 Claude 與 Grok 的登入及安全驗證頁強化進入流程。本版仍遵守 feature-frozen 範圍：修正並穩定既有 workflow，不增加新的產品介面。
+
+## Complete Brainstorm workflow / 完整腦力激盪流程
+
+- Every Brainstorm round now includes Claude, Gemini, Grok, and ChatGPT once. Twelve rounds produce 48 contributions instead of treating 12 as a total turn count.
+- 每輪都由 Claude、Gemini、Grok 與 ChatGPT 各回答一次；12 輪共 48 次發言，不再把 12 誤當成總發言數。
+- Speaking order rotates between rounds so no provider permanently owns the opening or closing position.
+- 每輪輪換發言順序，不讓任何 provider 固定取得開場或收尾位置。
+- Five phases guide the session through framing, divergence, cross-pollination, harvesting and selection, then testable concepts. Each turn receives the complete history of the same local conversation.
+- 五個階段依序完成問題框定、發散、交叉激發、收整選擇與可測試概念；每次發言都會收到同一本機 session 的完整前文。
+- Prompts require direct contributions and synthesis instead of asking the user to choose from follow-up options or offering to continue later.
+- Prompt 會要求直接貢獻與整合，不再自行丟出選項要求使用者選擇，也不會只提議稍後繼續。
+
+## Reliable long responses / 可靠的長時間回覆
+
+- Provider thinking state, newly received response chunks, bulk-ready content, completion signals, and a new document boot all count as activity and refresh the inactivity timeout.
+- Provider 的思考狀態、新回覆片段、批次就緒內容、完成訊號與新的 document boot 都視為活動，會刷新 inactivity timeout。
+- A separate 60-minute absolute cap remains in force even when a stale page keeps reporting `thinking`, preventing an infinite workflow wait.
+- 即使過期頁面持續回報 `thinking`，仍受獨立的 60 分鐘絕對上限限制，避免 workflow 永久等待。
+- Regression tests cover long thinking, chunk activity, completion activity, new boots, inactivity expiry, and the absolute timeout.
+- Regression tests 涵蓋長時間思考、片段活動、完成活動、新 boot、inactivity 到期與 absolute timeout。
+
+## Claude and Grok entry hardening / Claude 與 Grok 進入流程強化
+
+- Claude adapter version 4 recognizes current account login fields and Google SSO entry without attempting to automate credentials.
+- Claude adapter version 4 能辨識目前的帳號登入欄位與 Google SSO 入口，不會嘗試自動操作帳號密碼。
+- Cloudflare and hCaptcha signals defer bridge startup for every provider until the challenge page clears. The app does not bypass provider security checks.
+- 所有 provider 遇到 Cloudflare 或 hCaptcha 訊號時，都會延後 bridge 啟動直到驗證頁結束；本 app 不會繞過 provider 安全驗證。
+- Grok pages continue without History API monkey-patching, reducing interference with login and challenge navigation.
+- Grok 頁面不再 monkey-patch History API，降低對登入與安全驗證導覽的干擾。
+
+## Contributor thanks / 貢獻者致謝
+
+Thanks to Dave Tseng ([`@DaveTseng2019`](https://github.com/DaveTseng2019)) for identifying the fixed-timeout root cause and proposing the core keepalive implementation in [PR #34](https://github.com/teddashh/multi-ai-chat-desktop/pull/34). Commit `1d7ebb3` preserves his co-authorship; the release integration extends the fix to every response activity signal, adds the absolute safety cap, and supplies regression coverage.
+
+感謝 Dave Tseng（[`@DaveTseng2019`](https://github.com/DaveTseng2019)）在 [PR #34](https://github.com/teddashh/multi-ai-chat-desktop/pull/34) 找出固定逾時的 root cause，並提出 keepalive 核心實作。Commit `1d7ebb3` 保留其共同作者資訊；release 整合再補齊所有回覆活動訊號、absolute safety cap 與 regression coverage。
+
+## Validation / 驗證
+
+- The release branch passes 416 frontend tests across 51 files, 21 Agent contract tests, TypeScript type-checking, ESLint, adapter checks, production build, npm audit, 54 Rust tests, `cargo fmt --check`, and warnings-denied Clippy.
+- Release branch 通過 51 個檔案共 416 個 frontend tests、21 個 Agent contract tests、TypeScript type-check、ESLint、adapter checks、production build、npm audit、54 個 Rust tests、`cargo fmt --check` 與 warnings-denied Clippy。
+- Pull-request CI and CodeQL pass, including warnings-denied Clippy on Windows, macOS, and Linux.
+- Pull-request CI 與 CodeQL 全數通過，包含 Windows、macOS、Linux 的 warnings-denied Clippy。
+- The immutable `v1.6.2` tag rebuilds the Windows installer and portable zip, Apple Silicon DMG, and Linux AppImage before the release is published.
+- Immutable `v1.6.2` tag 會重新建置 Windows installer／portable zip、Apple Silicon DMG 與 Linux AppImage；全部產物完成後才發布正式版本。
+
+## Accepted upstream risk / 已接受的上游風險
+
+- The current Tauri/Wry Linux GTK3 dependency graph retains the documented medium-severity `glib::VariantStrIter` advisory. The app does not directly call the affected API, and the compatible upstream graph does not yet provide the newer `glib` line.
+- 目前 Tauri／Wry 的 Linux GTK3 dependency graph 仍有已記錄的 medium-severity `glib::VariantStrIter` advisory。本 app 未直接呼叫受影響 API，而相容的上游 graph 尚未提供新版 `glib`。
+
+## Downloads / 下載
+
+- Windows x64 installer and portable zip
+- Apple Silicon macOS DMG
+- Linux x86_64 AppImage
+
+## Notes / 注意事項
+
+- Windows artifacts remain unsigned and may trigger SmartScreen.
+- Windows 產物仍未簽章，可能觸發 SmartScreen。
+- The macOS package is ad-hoc signed and signature-verified in CI, but is not Apple-notarized; follow the README first-launch steps if Gatekeeper blocks it.
+- macOS package 使用 ad-hoc 簽章並由 CI 驗證，但尚未 Apple notarize；若 Gatekeeper 阻擋，請依 README 的首次啟動步驟操作。
+- Grok login and Cloudflare verification remain third-party behavior and may vary by network, account, or provider changes. CI verifies packaging and challenge deferral but does not claim a real-account login result.
+- Grok 登入與 Cloudflare 驗證屬第三方行為，可能因網路、帳號或 provider 改版而異；CI 會驗證封裝與 challenge deferral，但不宣稱已完成真實帳號登入測試。
+- A full 48-contribution live Brainstorm run requires four authenticated provider accounts and is not represented as an automated end-user smoke result.
+- 完整 48 次發言的 live Brainstorm 需要四個已登入 provider 帳號，不會被描述為自動化 end-user smoke 結果。
+- Linux remains CI-packaged without a new maintainer-owned real-device launch report.
+- Linux 仍由 CI 封裝，本版沒有 maintainer 自有實機的最新啟動回報。
+- Provider websites can change independently. Attach a sanitized exported debug log when reporting automation failures.
+- Provider 網頁可能獨立改版；回報自動化失敗時，請附上已去識別化的匯出 debug log。
+
+**Full changelog:** https://github.com/teddashh/multi-ai-chat-desktop/compare/v1.6.1...v1.6.2


### PR DESCRIPTION
## Summary
- prepare the stable `v1.6.2` maintenance release after merging #35
- update English, Traditional Chinese, Japanese, and German README highlights
- add bilingual release notes covering the complete 12-round/48-contribution Brainstorm workflow
- document provider challenge hardening, long-task keepalive semantics, Dave Tseng's contribution in #34, validation evidence, and platform limitations

## Validation inherited from #35
- 416 frontend tests and 21 Agent contract tests
- TypeScript typecheck, ESLint, adapter checks, production build, and npm audit
- 54 Rust tests, `cargo fmt --check`, and warnings-denied Clippy
- PR CI and CodeQL green on Windows, macOS, and Linux

This PR changes documentation only. After merge, the immutable `v1.6.2` tag will run the full three-platform release workflow and create a draft release for artifact review.