### PR TITLE
fix: harden stable desktop lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
         with:
           components: clippy
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           cache: pnpm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
 
       - name: Install Linux WebKitGTK build deps
         if: matrix.platform == 'linux'

--- a/LICENSE
+++ b/LICENSE
@@ -12,10 +12,6 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-Attribution: portions are adapted from teddashh/multi-ai-chat and may later
-adapt host/proxy or CI patterns from tony1223/better-agent-terminal, both MIT
-licensed reference projects.
-
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,10 @@
+# Notices
+
+Multi-AI Chat Desktop is distributed under the [MIT License](./LICENSE).
+
+Portions of this project adapt MIT-licensed ideas or implementation patterns from:
+
+- [`teddashh/multi-ai-chat`](https://github.com/teddashh/multi-ai-chat)
+- [`tony1223/better-agent-terminal`](https://github.com/tony1223/better-agent-terminal)
+
+The repository history and study notes retain more detailed provenance where applicable.

--- a/src-tauri/src/webviews.rs
+++ b/src-tauri/src/webviews.rs
@@ -180,7 +180,6 @@ pub async fn provider_open(
     let label = provider_label(&provider);
     if let Some(webview) = app.get_webview(&label) {
         webview.show().map_err(|error| error.to_string())?;
-        webview.set_focus().map_err(|error| error.to_string())?;
         set_webview_bounds(&webview, position, size)?;
         let state = current_state(&provider);
         return Ok(state);
@@ -531,6 +530,7 @@ pub async fn provider_new_session(
         tokio::time::sleep(Duration::from_millis(NEW_SESSION_READY_POLL_MS)).await;
     }
 
+    cancel_session_reset(&provider);
     Err(format!(
         "provider new session did not become ready within {} seconds: {provider}",
         NEW_SESSION_READY_TIMEOUT_SECS
@@ -987,9 +987,10 @@ mod tests {
     use tauri::{PhysicalPosition, PhysicalSize};
 
     use super::{
-        bridge_resets_on_boot_rotation, challenge_auxiliary_navigation_allowed,
-        decide_new_window_action, eval_callback_reports_true, fresh_session_boot, physical_bounds,
-        popup_initial_title, provider_show_should_focus, provider_uses_permission_shim, runtime,
+        accept_status_for_session_reset, bridge_resets_on_boot_rotation, cancel_session_reset,
+        challenge_auxiliary_navigation_allowed, decide_new_window_action,
+        eval_callback_reports_true, fresh_session_boot, physical_bounds, popup_initial_title,
+        provider_show_should_focus, provider_uses_permission_shim, runtime,
         should_reset_bridge_on_boot_rotation, staleness_action, state_with, Bounds,
         NewWindowAction, StalenessAction, PROVIDER_BROWSER_ARGS,
     };
@@ -1289,6 +1290,26 @@ mod tests {
         assert!(!eval_callback_reports_true("false"));
         assert!(!eval_callback_reports_true(r#""false""#));
         assert!(!eval_callback_reports_true("null"));
+    }
+
+    #[test]
+    fn cancelled_session_reset_accepts_status_from_the_current_document_again() {
+        let provider = "test-cancelled-session-reset";
+        {
+            let mut guard = runtime().lock().expect("provider runtime lock");
+            guard.status_boot.insert(provider.into(), "boot-a".into());
+            guard
+                .pending_session_boot
+                .insert(provider.into(), Some("boot-a".into()));
+        }
+
+        assert!(!accept_status_for_session_reset(provider, Some("boot-a")));
+        cancel_session_reset(provider);
+        assert!(accept_status_for_session_reset(provider, Some("boot-a")));
+
+        let mut guard = runtime().lock().expect("provider runtime lock");
+        guard.status_boot.remove(provider);
+        guard.pending_session_boot.remove(provider);
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -563,14 +563,28 @@ export default function App() {
   }, []);
 
   useEffect(() => {
+    let disposed = false;
     let unlisten: (() => void) | undefined;
     void host.adapter
       .onNotice((notice) => {
+        if (disposed) return;
         setAdapterNotice(notice);
         recordEventLog(eventFromAdapterNotice(notice));
       })
-      .then((fn) => (unlisten = fn));
-    return () => unlisten?.();
+      .then((fn) => {
+        if (disposed) {
+          fn();
+          return;
+        }
+        unlisten = fn;
+      })
+      .catch(() => {
+        // Adapter notices are diagnostic-only and must not interrupt startup.
+      });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
   }, []);
 
   useEffect(() => {

--- a/src/__tests__/m4a-ui.test.ts
+++ b/src/__tests__/m4a-ui.test.ts
@@ -82,6 +82,26 @@ describe('M4a UI helpers', () => {
     expect(show.mock.calls.map(([provider]) => provider)).toEqual(['chatgpt', 'claude']);
   });
 
+  it('serializes a rapid overlay restore behind an in-flight hide', async () => {
+    const guard = new OverlayGuardCounter();
+    let finishHide: (() => void) | undefined;
+    const hidePending = new Promise<void>((resolve) => {
+      finishHide = resolve;
+    });
+    const hide = vi.fn(() => hidePending);
+    const show = vi.fn(async () => {});
+    const host = { hide, show };
+
+    guard.open(['chatgpt'], host);
+    guard.close(host);
+
+    expect(hide).toHaveBeenCalledWith('chatgpt');
+    expect(show).not.toHaveBeenCalled();
+
+    finishHide?.();
+    await vi.waitFor(() => expect(show).toHaveBeenCalledWith('chatgpt'));
+  });
+
   it('maps preflight unavailable and aliased providers to labelled dialog rows with reasons', () => {
     const model = buildPreflightDialogModel(
       'debate',

--- a/src/__tests__/n5-presentation.test.ts
+++ b/src/__tests__/n5-presentation.test.ts
@@ -399,7 +399,7 @@ describe('N5 webview presentation host commands', () => {
     expect(host.hide).toHaveBeenCalledWith('claude');
 
     guard.close(overlayHost);
-    expect(host.show).toHaveBeenCalledWith('claude');
+    await vi.waitFor(() => expect(host.show).toHaveBeenCalledWith('claude'));
     expect(host.show).toHaveBeenCalledTimes(1);
   });
 

--- a/src/ui/SettingsModal.tsx
+++ b/src/ui/SettingsModal.tsx
@@ -71,6 +71,7 @@ export function SettingsModal({
   const settingsPersistenceRef = useRef(createSettingsPersistence(host.settings));
   const fontSizeDebounceRef = useRef<TrailingDebounce<PendingFontSizeUpdate> | undefined>(undefined);
   const modalSessionRef = useRef(0);
+  const updateCheckSeqRef = useRef(0);
   const draftUpdateSeqRef = useRef(0);
   const languageUpdateSeqRef = useRef(0);
   const fontSizeUpdateSeqRef = useRef(0);
@@ -247,10 +248,15 @@ export function SettingsModal({
   };
 
   const checkForUpdates = async () => {
+    const modalSession = modalSessionRef.current;
+    const updateCheckSeq = ++updateCheckSeqRef.current;
+    const isCurrent = () => modalSession === modalSessionRef.current && updateCheckSeq === updateCheckSeqRef.current;
     setUpdateCheck({ status: 'checking' });
     try {
       const currentVersion = await host.app.version();
+      if (!isCurrent()) return;
       const latest = await fetchLatestRelease();
+      if (!isCurrent()) return;
       if (!latest) {
         setUpdateCheck({ status: 'unavailable' });
         return;
@@ -261,6 +267,7 @@ export function SettingsModal({
         setUpdateCheck({ status: 'up-to-date', version: currentVersion });
       }
     } catch (reason) {
+      if (!isCurrent()) return;
       setUpdateCheck({ status: 'error', message: reason instanceof Error ? reason.message : String(reason) });
     }
   };

--- a/src/ui/overlayGuard.ts
+++ b/src/ui/overlayGuard.ts
@@ -8,12 +8,13 @@ export interface OverlayGuardHost {
 export class OverlayGuardCounter {
   private openCount = 0;
   private hiddenProviders: AIProvider[] = [];
+  private commandChains = new Map<AIProvider, Promise<void>>();
 
   open(loadedProviders: AIProvider[], host: OverlayGuardHost): void {
     this.openCount += 1;
     if (this.openCount !== 1) return;
     this.hiddenProviders = [...loadedProviders];
-    for (const provider of this.hiddenProviders) void host.hide(provider);
+    for (const provider of this.hiddenProviders) this.enqueue(provider, () => host.hide(provider));
   }
 
   reconcile(loadedProviders: AIProvider[], host: OverlayGuardHost): void {
@@ -25,7 +26,7 @@ export class OverlayGuardCounter {
       if (hidden.has(provider)) continue;
       this.hiddenProviders.push(provider);
       hidden.add(provider);
-      void host.hide(provider);
+      this.enqueue(provider, () => host.hide(provider));
     }
   }
 
@@ -35,7 +36,7 @@ export class OverlayGuardCounter {
     if (this.openCount !== 0) return;
     const toRestore = this.hiddenProviders;
     this.hiddenProviders = [];
-    for (const provider of toRestore) void host.show(provider);
+    for (const provider of toRestore) this.enqueue(provider, () => host.show(provider));
   }
 
   reset(): void {
@@ -45,6 +46,37 @@ export class OverlayGuardCounter {
 
   get count(): number {
     return this.openCount;
+  }
+
+  private enqueue(provider: AIProvider, command: () => Promise<void> | void): void {
+    const previous = this.commandChains.get(provider);
+    if (!previous) {
+      const pending = runOverlayCommand(command);
+      if (pending) this.track(provider, pending);
+      return;
+    }
+
+    this.track(
+      provider,
+      previous.then(() => runOverlayCommand(command)).then(() => undefined),
+    );
+  }
+
+  private track(provider: AIProvider, pending: Promise<void>): void {
+    this.commandChains.set(provider, pending);
+    void pending.then(() => {
+      if (this.commandChains.get(provider) === pending) this.commandChains.delete(provider);
+    });
+  }
+}
+
+function runOverlayCommand(command: () => Promise<void> | void): Promise<void> | undefined {
+  try {
+    const result = command();
+    if (!result || typeof result.then !== 'function') return undefined;
+    return Promise.resolve(result).catch(() => undefined);
+  } catch {
+    return undefined;
   }
 }
 


### PR DESCRIPTION
## Summary
- serialize provider WebView hide/show commands so a rapid modal close cannot leave a provider hidden
- clean up late async adapter-notice subscriptions under React StrictMode
- ignore stale update-check results after Settings closes or a newer request starts
- avoid stealing focus when an already-open provider is restored in the background
- clear timed-out provider session-reset state so the current document can report status again
- pin the Rust toolchain action to an immutable commit and restore standard MIT license detection with a separate NOTICE file

## Root causes
Several asynchronous lifecycle operations were previously fire-and-forget. Their completion order could outlive the UI state that started them: a late hide could beat a later show, a listener subscription could resolve after cleanup, and modal/update or session-reset state could survive its owning operation. Existing provider restoration also focused an already-open WebView even when no explicit focus was requested.

## Impact
This is a feature-frozen stability patch. It does not add a workflow, provider, or product surface. It reduces overlay/focus surprises, stale settings state, duplicate diagnostic listeners, and session-reset recovery failures.

## Validation
- `pnpm verify` — 417 frontend tests, 21 Agent contract tests, typecheck, lint, adapter checks
- `pnpm build`
- `pnpm audit --audit-level=low` — no known vulnerabilities
- 55 Rust tests
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

Claude and Grok were also used for an independent focused review; only evidence-backed, low-risk findings were included.
