### PR TITLE
feat: add a temporary expand toggle for the focus stage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -321,6 +321,7 @@ export default function App() {
   const [initialRestoreComplete, setInitialRestoreComplete] = useState(false);
   const [connectionSnapshotLoaded, setConnectionSnapshotLoaded] = useState(false);
   const [focusPaneWidth, setFocusPaneWidth] = useState(() => defaultSettings().focusPaneWidth);
+  const [stageExpanded, setStageExpanded] = useState(false);
   const [presentation, setPresentation] = useState<PresentationByProvider>(() => defaultPresentation());
   const [centerSurface, setCenterSurface] = useState<CenterSurface>('text');
   const [userHidden, setUserHidden] = useState<Set<AIProvider>>(() => new Set());
@@ -1817,10 +1818,14 @@ export default function App() {
             onDeleteSession={deleteConversationSession}
           />
           <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+            {/* 放大檢視時暫時收起選單區讓 webview 吃滿高度；checkpoint / 逾時對話框
+                是 inline 渲染在這個區塊內，出現時必須讓區塊重新顯示，否則使用者按不到。 */}
             <section
               id="workflow-control-shelf"
               aria-label={translate('preset.catalog.aria')}
-              className="ai-sister-workflow-shelf max-h-[42vh] shrink-0 overflow-auto border-b border-zinc-200 bg-zinc-50/80 p-3 dark:border-zinc-800 dark:bg-zinc-900/70"
+              className={`ai-sister-workflow-shelf max-h-[42vh] shrink-0 overflow-auto border-b border-zinc-200 bg-zinc-50/80 p-3 dark:border-zinc-800 dark:bg-zinc-900/70 ${
+                stageExpanded && !checkpoint && !(stepTimeout && !stepTimeout.timedOut) ? 'hidden' : ''
+              }`}
             >
               <AiSisterEnsembleCard />
               <PresetCatalog
@@ -1889,6 +1894,8 @@ export default function App() {
                 const container = transcriptRef.current;
                 if (container) scrollTranscriptToProviderMessage(container, provider);
               }}
+              stageExpanded={stageExpanded}
+              onToggleStageExpanded={() => setStageExpanded((current) => !current)}
             />
           </div>
         </div>

--- a/src/__tests__/FocusPaneHeader.test.tsx
+++ b/src/__tests__/FocusPaneHeader.test.tsx
@@ -29,10 +29,12 @@ function renderFocusPane({
   stateOverrides,
   presentation = defaultPresentation(),
   centeredProvider = 'chatgpt',
+  stageExpanded,
 }: {
   stateOverrides?: Partial<Record<AIProvider, Partial<ProviderState>>>;
   presentation?: PresentationByProvider;
   centeredProvider?: AIProvider | null;
+  stageExpanded?: boolean;
 }): string {
   return renderToStaticMarkup(
     <I18nProvider language="en">
@@ -54,6 +56,8 @@ function renderFocusPane({
         syncBounds={vi.fn().mockResolvedValue(undefined)}
         reportProvider={vi.fn().mockResolvedValue(undefined)}
         reportBusy={false}
+        stageExpanded={stageExpanded}
+        onToggleStageExpanded={stageExpanded === undefined ? undefined : vi.fn()}
       />
     </I18nProvider>,
   );
@@ -96,6 +100,16 @@ describe('FocusPane provider header', () => {
     expect(html).toContain('Choose an AI to get started');
     expect(html).toContain('Open ChatGPT');
     expect(html).toContain('Open Grok');
+  });
+
+  it('hides the connection strip while the stage is temporarily expanded so the webview gets the full pane', () => {
+    const collapsed = renderFocusPane({ stageExpanded: false });
+    const expanded = renderFocusPane({ stageExpanded: true });
+
+    expect(collapsed).toContain('Expand');
+    expect(collapsed).toContain('AI connections');
+    expect(expanded).toContain('Restore');
+    expect(expanded).not.toContain('AI connections');
   });
 
   it('uses a fixed-px stage floor that cannot out-grow the connection strip at large font sizes', () => {

--- a/src/__tests__/FocusPaneHeader.test.tsx
+++ b/src/__tests__/FocusPaneHeader.test.tsx
@@ -30,11 +30,13 @@ function renderFocusPane({
   presentation = defaultPresentation(),
   centeredProvider = 'chatgpt',
   stageExpanded,
+  stageToggleEnabled = true,
 }: {
   stateOverrides?: Partial<Record<AIProvider, Partial<ProviderState>>>;
   presentation?: PresentationByProvider;
   centeredProvider?: AIProvider | null;
   stageExpanded?: boolean;
+  stageToggleEnabled?: boolean;
 }): string {
   return renderToStaticMarkup(
     <I18nProvider language="en">
@@ -57,7 +59,7 @@ function renderFocusPane({
         reportProvider={vi.fn().mockResolvedValue(undefined)}
         reportBusy={false}
         stageExpanded={stageExpanded}
-        onToggleStageExpanded={stageExpanded === undefined ? undefined : vi.fn()}
+        onToggleStageExpanded={stageExpanded === undefined || !stageToggleEnabled ? undefined : vi.fn()}
       />
     </I18nProvider>,
   );
@@ -110,6 +112,13 @@ describe('FocusPane provider header', () => {
     expect(collapsed).toContain('AI connections');
     expect(expanded).toContain('Restore');
     expect(expanded).not.toContain('AI connections');
+  });
+
+  it('ignores an expanded state when no restore callback is available', () => {
+    const html = renderFocusPane({ stageExpanded: true, stageToggleEnabled: false });
+
+    expect(html).not.toContain('Restore');
+    expect(html).toContain('AI connections');
   });
 
   it('uses a fixed-px stage floor that cannot out-grow the connection strip at large font sizes', () => {

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -106,6 +106,8 @@ export const de: Record<I18nKey, string> = {
   'provider.access.selectorTextExcludes': 'Text enthält nicht „{value}“',
   'provider.realPage': 'Originalseite',
   'provider.textView': 'Text',
+  'provider.expandStage': 'Vergrößern',
+  'provider.collapseStage': 'Zurücksetzen',
   'provider.center': 'Mitte',
   'provider.connections': 'KI-Verbindungen',
   'provider.connectionsHint': 'KI zum Fokussieren oder Verbinden auswählen',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -104,6 +104,8 @@ export const en: Record<I18nKey, string> = {
   'provider.access.selectorTextExcludes': 'text excludes "{value}"',
   'provider.realPage': 'Real page',
   'provider.textView': 'Text',
+  'provider.expandStage': 'Expand',
+  'provider.collapseStage': 'Restore',
   'provider.center': 'Center',
   'provider.connections': 'AI connections',
   'provider.connectionsHint': 'Choose an AI to focus or connect',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -106,6 +106,8 @@ export const ja: Record<I18nKey, string> = {
   'provider.access.selectorTextExcludes': 'テキストに「{value}」を含まない',
   'provider.realPage': '実際のページ',
   'provider.textView': 'テキスト',
+  'provider.expandStage': '拡大',
+  'provider.collapseStage': '元に戻す',
   'provider.center': '中央',
   'provider.connections': 'AI接続',
   'provider.connectionsHint': 'フォーカスまたは接続するAIを選択',

--- a/src/i18n/keys.ts
+++ b/src/i18n/keys.ts
@@ -87,6 +87,8 @@ export const I18N_KEYS = [
   'provider.access.selectorTextExcludes',
   'provider.realPage',
   'provider.textView',
+  'provider.expandStage',
+  'provider.collapseStage',
   'provider.center',
   'provider.connections',
   'provider.connectionsHint',

--- a/src/i18n/zh-TW.ts
+++ b/src/i18n/zh-TW.ts
@@ -94,6 +94,8 @@ export const zhTW: Record<I18nKey, string> = {
   'provider.access.selectorTextExcludes': '文字排除「{value}」',
   'provider.realPage': '真實頁面',
   'provider.textView': '文字',
+  'provider.expandStage': '放大',
+  'provider.collapseStage': '還原',
   'provider.center': '置中',
   'provider.connections': 'AI 連線',
   'provider.connectionsHint': '選擇要聚焦或連線的 AI',

--- a/src/ui/FocusPane.tsx
+++ b/src/ui/FocusPane.tsx
@@ -43,6 +43,8 @@ export function FocusPane({
   processTrace,
   onTraceDetailOpenChange,
   onChipClick,
+  stageExpanded = false,
+  onToggleStageExpanded,
 }: {
   centeredProvider?: AIProvider;
   states: Record<AIProvider, ProviderState>;
@@ -66,6 +68,8 @@ export function FocusPane({
   processTrace?: ProcessTraceState;
   onTraceDetailOpenChange?: (open: boolean) => void;
   onChipClick?: (provider: AIProvider) => void;
+  stageExpanded?: boolean;
+  onToggleStageExpanded?: () => void;
 }) {
   const { locale, t } = useI18n();
   const [providerAction, setProviderAction] = useState<ProviderActionState | undefined>();
@@ -108,6 +112,8 @@ export function FocusPane({
           syncBounds={syncBounds}
           reportProvider={reportProvider}
           reportBusy={reportBusy}
+          stageExpanded={stageExpanded}
+          onToggleStageExpanded={onToggleStageExpanded}
         />
       ) : (
         <FirstRunPanel
@@ -130,8 +136,9 @@ export function FocusPane({
         </div>
       ) : null}
 
-      {processTrace ? <ProcessTrace trace={processTrace} locale={locale} onDetailOpenChange={onTraceDetailOpenChange} /> : null}
+      {processTrace && !stageExpanded ? <ProcessTrace trace={processTrace} locale={locale} onDetailOpenChange={onTraceDetailOpenChange} /> : null}
 
+      {stageExpanded ? null : (
       <StatusStrip
         centeredProvider={centeredProvider}
         states={states}
@@ -141,6 +148,7 @@ export function FocusPane({
         openingProvider={openingProvider}
         onChipClick={onChipClick}
       />
+      )}
     </aside>
   );
 }
@@ -215,6 +223,8 @@ function FocusStage({
   syncBounds,
   reportProvider,
   reportBusy,
+  stageExpanded,
+  onToggleStageExpanded,
 }: {
   provider: AIProvider;
   state: ProviderState;
@@ -233,6 +243,8 @@ function FocusStage({
   syncBounds: (provider: AIProvider) => Promise<void>;
   reportProvider: (provider: AIProvider) => Promise<void>;
   reportBusy: boolean;
+  stageExpanded: boolean;
+  onToggleStageExpanded?: () => void;
 }) {
   const { t } = useI18n();
   const [moreMenuOpen, setMoreMenuOpen] = useState(false);
@@ -279,6 +291,16 @@ function FocusStage({
               {t('provider.textView')}
             </button>
           )}
+          {onToggleStageExpanded ? (
+            <button
+              type="button"
+              className="border border-zinc-300 dark:border-zinc-700 px-2 py-1 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+              aria-pressed={stageExpanded}
+              onClick={onToggleStageExpanded}
+            >
+              {stageExpanded ? t('provider.collapseStage') : t('provider.expandStage')}
+            </button>
+          ) : null}
           {showLoginCta ? (
             <button
               type="button"

--- a/src/ui/FocusPane.tsx
+++ b/src/ui/FocusPane.tsx
@@ -74,6 +74,7 @@ export function FocusPane({
   const { locale, t } = useI18n();
   const [providerAction, setProviderAction] = useState<ProviderActionState | undefined>();
   const providerActionGeneration = useRef(0);
+  const effectiveStageExpanded = stageExpanded && Boolean(onToggleStageExpanded);
 
   const activateProvider = async (provider: AIProvider) => {
     const generation = (providerActionGeneration.current += 1);
@@ -112,7 +113,7 @@ export function FocusPane({
           syncBounds={syncBounds}
           reportProvider={reportProvider}
           reportBusy={reportBusy}
-          stageExpanded={stageExpanded}
+          stageExpanded={effectiveStageExpanded}
           onToggleStageExpanded={onToggleStageExpanded}
         />
       ) : (
@@ -136,18 +137,18 @@ export function FocusPane({
         </div>
       ) : null}
 
-      {processTrace && !stageExpanded ? <ProcessTrace trace={processTrace} locale={locale} onDetailOpenChange={onTraceDetailOpenChange} /> : null}
+      {processTrace && !effectiveStageExpanded ? <ProcessTrace trace={processTrace} locale={locale} onDetailOpenChange={onTraceDetailOpenChange} /> : null}
 
-      {stageExpanded ? null : (
-      <StatusStrip
-        centeredProvider={centeredProvider}
-        states={states}
-        presentation={presentation}
-        setPaneRef={setPaneRef}
-        activateProvider={activateProvider}
-        openingProvider={openingProvider}
-        onChipClick={onChipClick}
-      />
+      {effectiveStageExpanded ? null : (
+        <StatusStrip
+          centeredProvider={centeredProvider}
+          states={states}
+          presentation={presentation}
+          setPaneRef={setPaneRef}
+          activateProvider={activateProvider}
+          openingProvider={openingProvider}
+          onChipClick={onChipClick}
+        />
       )}
     </aside>
   );


### PR DESCRIPTION
## Problem

During a workflow run the focused provider's real page becomes cramped: the workflow shelf (up to 42vh), the process trace, and the connection strip all compete for the left pane, leaving the embedded webview too small to actually read the provider's page.

## Cause

The focus stage shares the pane with three always-visible sections and has no way to temporarily reclaim that space; the native webview simply follows whatever rect the center stage placeholder is given.

## Fix

Add an **Expand / Restore** toggle in the focus stage header (next to Real page / Text):

- While expanded, the workflow shelf, process trace, and connection strip are hidden, so the stage - and the native webview anchored to it - fills the full pane height. The existing `ResizeObserver` on the center stage re-syncs the webview bounds automatically; no new bounds plumbing.
- The checkpoint card and step-timeout dialog render inline inside the workflow shelf, so the shelf reappears whenever either is active; expanding can never hide an actionable dialog.
- Plain component state, not persisted: the layout always starts restored.
- New `provider.expandStage` / `provider.collapseStage` strings in all four locales.

## Verification

- `npm run typecheck` - clean
- `npx vitest run` - 51 files, 418 tests passed, including a new `FocusPaneHeader` test asserting the connection strip is hidden and the Restore label shown while expanded
- Manual: launched the dev app, opened ChatGPT's real page, toggled Expand/Restore - webview grows to the full pane and restores cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)