### PR TITLE
fix: wait for providers to become sendable again after session reset

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,6 +108,7 @@ import {
   freeModeTargets,
   hasEffectiveFreeModeTargets,
   markFreeTargetsTouched,
+  waitForProvidersSendable,
   type FreeTargetSelection,
 } from './ui/targets';
 import { useOverlayGuard } from './ui/useOverlayGuard';
@@ -1462,6 +1463,10 @@ export default function App() {
         });
         if (providerSessionResetAttemptRef.current !== resetAttempt) return false;
         for (const provider of providersToFreshen) pendingProviderResetRef.current.delete(provider);
+        // 重置後頁面重新導航，login 狀態要等下一輪 STATUS_REPORT 才回穩；
+        // 不等的話 fan-out 目標會被暫時性的 logged_out/blocked 誤過濾掉。
+        await waitForProvidersSendable(participants, () => statesRef.current);
+        if (providerSessionResetAttemptRef.current !== resetAttempt) return false;
         setWorkflowStatus('');
       } catch (reason) {
         const resetError = reason instanceof ProviderSessionResetError ? reason : undefined;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1465,7 +1465,13 @@ export default function App() {
         for (const provider of providersToFreshen) pendingProviderResetRef.current.delete(provider);
         // 重置後頁面重新導航，login 狀態要等下一輪 STATUS_REPORT 才回穩；
         // 不等的話 fan-out 目標會被暫時性的 logged_out/blocked 誤過濾掉。
-        await waitForProvidersSendable(participants, () => statesRef.current);
+        await waitForProvidersSendable(
+          providersToFreshen,
+          () => statesRef.current,
+          undefined,
+          undefined,
+          () => providerSessionResetAttemptRef.current !== resetAttempt,
+        );
         if (providerSessionResetAttemptRef.current !== resetAttempt) return false;
         setWorkflowStatus('');
       } catch (reason) {

--- a/src/__tests__/m4a-ui.test.ts
+++ b/src/__tests__/m4a-ui.test.ts
@@ -21,6 +21,7 @@ import {
   hasEffectiveFreeModeTargets,
   markFreeTargetsTouched,
   toggleTarget,
+  waitForProvidersSendable,
 } from '../ui/targets';
 import { processingAfterSend, processingAfterSettle, processingAfterWorkflowStatus } from '../ui/processing';
 import { chooseTimeoutDialogAction } from '../ui/timeoutActions';
@@ -181,6 +182,28 @@ describe('M4a UI helpers', () => {
 
     expect(hasEffectiveFreeModeTargets([], unavailable)).toBe(false);
     expect(freeModeTargets([], unavailable)).toEqual([]);
+  });
+
+  // Session reset 後第一輪狀態回報會短暫誤報未登入；若不等待回穩,
+  // fan-out 會默默丟掉暫時不可送的目標(4 選 1 出 bug)。
+  it('waits for transiently non-sendable providers to recover before fan-out', async () => {
+    vi.useFakeTimers();
+    try {
+      let current = states({ claude: state('claude', false), grok: state('grok', false) });
+      const wait = waitForProvidersSendable(providers, () => current, 20_000, 250);
+      await vi.advanceTimersByTimeAsync(500);
+      current = states();
+      await vi.advanceTimersByTimeAsync(500);
+      await expect(wait).resolves.toBeUndefined();
+      expect(freeModeTargets(providers, current)).toEqual(providers);
+
+      current = states({ claude: state('claude', false) });
+      const timedOut = waitForProvidersSendable(providers, () => current, 1_000, 250);
+      await vi.advanceTimersByTimeAsync(1_500);
+      await expect(timedOut).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('records timeout dialog retry, skip, and cancel actions', async () => {

--- a/src/ui/targets.ts
+++ b/src/ui/targets.ts
@@ -36,13 +36,16 @@ export async function waitForProvidersSendable(
   getStates: () => Record<AIProvider, ProviderState>,
   timeoutMs = 20_000,
   pollMs = 250,
+  shouldAbort?: () => boolean,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (providers.every((provider) => isSendable(getStates()[provider]))) return;
+    if (shouldAbort?.()) return;
+    const states = getStates();
+    if (providers.every((provider) => isSendable(states[provider]))) return;
     await new Promise((resolve) => setTimeout(resolve, pollMs));
   }
-  // ponytail: 超時就照舊只送 sendable 的（真的登出的 provider 最多多等 20 秒）
+  // 超時就照舊只送 sendable 的（真的登出的 provider 最多多等 20 秒）
 }
 
 export function hasEffectiveFreeModeTargets(selected: AIProvider[], states: Record<AIProvider, ProviderState>): boolean {

--- a/src/ui/targets.ts
+++ b/src/ui/targets.ts
@@ -28,6 +28,23 @@ export function freeModeTargets(selected: AIProvider[], states: Record<AIProvide
   return selected.filter((provider) => isSendable(states[provider]));
 }
 
+// Session reset 會讓 provider 頁面重新導航，導航後第一輪 STATUS_REPORT 常誤報
+// logged_out/blocked（login detector 還沒渲染出來），下一輪（約 10 秒後）才恢復。
+// 送出前等它們回穩，避免 fan-out 目標被暫時性的假狀態默默過濾掉。
+export async function waitForProvidersSendable(
+  providers: readonly AIProvider[],
+  getStates: () => Record<AIProvider, ProviderState>,
+  timeoutMs = 20_000,
+  pollMs = 250,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (providers.every((provider) => isSendable(getStates()[provider]))) return;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  // ponytail: 超時就照舊只送 sendable 的（真的登出的 provider 最多多等 20 秒）
+}
+
 export function hasEffectiveFreeModeTargets(selected: AIProvider[], states: Record<AIProvider, ProviderState>): boolean {
   return freeModeTargets(selected, states).length > 0;
 }


### PR DESCRIPTION
## Problem

In free fan-out mode with all 4 providers selected and shown as ready, only one provider actually received the question and produced an answer. The other three real pages never got the prompt.

## Cause

The first send after a conversation switch triggers a provider session reset (`ensureFreshProviderSessions`), which navigates every provider webview to a fresh chat. The first `STATUS_REPORT` after that navigation transiently reports `logged_out` / `blocked` because the login detectors haven't rendered yet; the next report (~10s later, on the status interval) recovers to `logged_in`.

The workflow computed `freeModeTargets` about 1 second after the reset, so the transient states silently filtered the selection down to whichever provider reported first. Diagnostic log from a repro:

```
07:01:12.6  session reset navigates all 4 webviews
07:01:13.6  Claude=logged_out, Grok=logged_out, Gemini=blocked (transient)
07:01:13.7  free workflow started … targetCount: 1   ← only ChatGPT survives
07:01:22.8  all providers report logged_in again — too late
```

## Fix

Add `waitForProvidersSendable` in `src/ui/targets.ts` (250ms poll, 20s cap) and call it in `send()` after a successful session reset, before fan-out targets are computed. Providers that are genuinely unavailable still get dropped after the cap, preserving existing behavior.

## Verification

- `npm run typecheck` clean
- `npx vitest run`: 426 tests pass, including a new test covering recovery after a transient non-sendable window and the timeout path
- Manual repro on Windows: after the fix, all 4 selected providers receive the prompt and all 4 responses render

🤖 Generated with [Claude Code](https://claude.com/claude-code)