### PR TITLE
Prepare v1.8.1 release

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -10,14 +10,14 @@ Stelle eine Frage und lasse deine angemeldeten Web-Sitzungen von **ChatGPT, Clau
 
 > **Projektstatus:** Die Funktionsentwicklung ist abgeschlossen. Das letzte optionale Gedenk-Theme mit allen vier AI-Sister-Figuren und das Brainstorming-Preset mit 12 Runden sind enthalten. Brainstorming behält vier wechselnde Sitze, insgesamt 48 Beiträge und den vollständigen Verlauf derselben Sitzung. Jedes integrierte Preset mit vier Rollen oder Sitzen weist ChatGPT, Claude, Gemini und Grok jeweils genau einmal zu. Danach werden nur Anbieterkompatibilität, Sicherheit und Build-Probleme gepflegt; Snapshot und Replay bleiben unverändert.
 
-## Neuerungen in v1.8.0
+## Neuerungen in v1.8.1
 
-- **Transkript über die volle Breite.** Eine Schaltfläche maximiert den Gesprächsbereich oder stellt ihn wieder her; Sidebar und Resizer sind dabei vollständig isoliert, ohne den Workflow zu unterbrechen.
-- **Aktuell gelesenen Anbieter erkennen.** Provider-Chips folgen der Leselinie; Größen- und Textumbruchänderungen werden automatisch neu berechnet.
-- **Sichere native Seitenwechsel.** Anmeldung, Preflight, Replay und Overlay-Wiederherstellung verwenden denselben aktuellen Provider-Zustand, damit keine veraltete WebView das Transkript überdeckt.
-- **Effiziente lange Gespräche.** Die Position wird über eine begrenzte binäre Suche ermittelt, nicht vor der ersten tatsächlich erreichten Provider-Nachricht gesetzt und in allen vier UI-Sprachen barrierefrei beschriftet.
+- **Korrekter Grok-Challenge-Status.** Ein Cloudflare-/Turnstile-Widget wird auch bei unverändertem Seitentitel als blockiert gemeldet, ohne die Automatisierungs-Bridge zu starten oder die Challenge-Seite zu verändern.
+- **Alle vier Anbieter in integrierten Vier-Rollen-Setups.** ChatGPT, Claude, Gemini und Grok werden jeweils einmal zugewiesen. Nur exakt übereinstimmende alte Standardwerte werden einmal migriert; benutzerdefinierte Belegungen bleiben erhalten.
+- **Replay-sichere Workflow-Änderungen.** Workflows mit geändertem Provider-Routing erhalten neue Versionen, damit inkompatible Snapshots und Replays ausdrücklich abgelehnt werden.
+- **Bereinigte Source-Toolchain.** Behebbare Sicherheitswarnungen der JavaScript-Entwicklungsabhängigkeiten sind beseitigt; der Agent-ready Source Contract verlangt nun Node.js 22.13.x oder 24+.
 
-Validierung, Mitwirkende, das dokumentierte GTK-Upstream-Risiko und bekannte Plattformgrenzen stehen in den zweisprachigen [`v1.8.0 Release Notes`](./docs/RELEASE_NOTES_v1.8.0.md).
+Validierung, Grok-Einschränkungen und ausstehende manuelle Release-Prüfungen stehen in den zweisprachigen [`v1.8.1 Release Notes`](./docs/RELEASE_NOTES_v1.8.1.md).
 
 ## Edition wählen
 

--- a/README.de.md
+++ b/README.de.md
@@ -15,7 +15,7 @@ Stelle eine Frage und lasse deine angemeldeten Web-Sitzungen von **ChatGPT, Clau
 - **Korrekter Grok-Challenge-Status.** Ein Cloudflare-/Turnstile-Widget wird auch bei unverändertem Seitentitel als blockiert gemeldet, ohne die Automatisierungs-Bridge zu starten oder die Challenge-Seite zu verändern.
 - **Alle vier Anbieter in integrierten Vier-Rollen-Setups.** ChatGPT, Claude, Gemini und Grok werden jeweils einmal zugewiesen. Nur exakt übereinstimmende alte Standardwerte werden einmal migriert; benutzerdefinierte Belegungen bleiben erhalten.
 - **Replay-sichere Workflow-Änderungen.** Workflows mit geändertem Provider-Routing erhalten neue Versionen, damit inkompatible Snapshots und Replays ausdrücklich abgelehnt werden.
-- **Bereinigte Source-Toolchain.** Behebbare Sicherheitswarnungen der JavaScript-Entwicklungsabhängigkeiten sind beseitigt; der Agent-ready Source Contract verlangt nun Node.js 22.13.x oder 24+.
+- **Bereinigte Source-Toolchain.** Behebbare Sicherheitswarnungen der JavaScript-Entwicklungsabhängigkeiten sind beseitigt; der Agent-ready Source Contract verlangt nun Node.js ^22.13.0 || >=24.0.0.
 
 Validierung, Grok-Einschränkungen und ausstehende manuelle Release-Prüfungen stehen in den zweisprachigen [`v1.8.1 Release Notes`](./docs/RELEASE_NOTES_v1.8.1.md).
 
@@ -105,7 +105,7 @@ Ist die Desktop-/Browser-Sitzung remote, verwende eine lokale Claude-Code-Sitzun
 
 ### Voraussetzungen nach Betriebssystem
 
-Allgemein: **Node.js 22.13.x oder 24+**, pnpm (oder Corepack) und stabiles Rust. Die folgenden Schritte sind manuelle Beispiele; der Skill meldet fehlende Voraussetzungen nur und beendet sich.
+Allgemein: **Node.js ^22.13.0 || >=24.0.0**, pnpm (oder Corepack) und stabiles Rust. Die folgenden Schritte sind manuelle Beispiele; der Skill meldet fehlende Voraussetzungen nur und beendet sich.
 
 **Windows 10/11**
 
@@ -128,7 +128,7 @@ sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
   libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
 ```
 
-Danach Node.js 22.13.x oder 24+ und Rust stable installieren und den Skill in einer X11-/Wayland-Sitzung ausführen. Andere Distributionen: [Tauri-2-Voraussetzungen](https://v2.tauri.app/start/prerequisites/).
+Danach Node.js ^22.13.0 || >=24.0.0 und Rust stable installieren und den Skill in einer X11-/Wayland-Sitzung ausführen. Andere Distributionen: [Tauri-2-Voraussetzungen](https://v2.tauri.app/start/prerequisites/).
 
 ### Skill-Befehle
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,7 +15,7 @@
 - **Grok challenge の状態を正確に表示。** Cloudflare／Turnstile widget が元のpage titleを維持していても、automation bridgeを開始したりchallenge pageを変更したりせず、blockedとして報告します。
 - **組み込みの4役設定で4 providerを使用。** ChatGPT、Claude、Gemini、Grokを1回ずつ割り当てます。旧標準設定と完全一致する設定だけを一度移行し、カスタム設定は変更しません。
 - **Snapshot／replay の互換性を保護。** Provider routingを変更したworkflow graphは新しいversionを使用し、互換性のないsnapshotやreplayを暗黙に別routingで実行せず明示的に拒否します。
-- **Source toolchain の安全性を改善。** 対応可能なJavaScript開発依存関係のadvisoryを解消し、Agent-ready source contractはNode.js 22.13.xまたは24+を明示的に要求します。
+- **Source toolchain の安全性を改善。** 対応可能なJavaScript開発依存関係のadvisoryを解消し、Agent-ready source contractはNode.js ^22.13.0 || >=24.0.0を明示的に要求します。
 
 検証結果、Grokの制限、残っている手動release gateは、日英併記の [`v1.8.1 release notes`](./docs/RELEASE_NOTES_v1.8.1.md) を参照してください。
 
@@ -105,7 +105,7 @@ desktop/browser session が remote の場合は、local Claude Code session を�
 
 ### OS別の前提条件
 
-共通：**Node.js 22.13.x または 24+**、pnpm（または Corepack）、stable Rust。以下は手動で前提条件を用意する例であり、Skill自体は不足項目を報告して停止します。
+共通：**Node.js ^22.13.0 || >=24.0.0**、pnpm（または Corepack）、stable Rust。以下は手動で前提条件を用意する例であり、Skill自体は不足項目を報告して停止します。
 
 **Windows 10/11**
 
@@ -128,7 +128,7 @@ sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
   libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
 ```
 
-Node.js 22.13.x または 24+ と Rust stable を追加し、X11／Wayland session でSkillを実行します。他のdistributionは [Tauri 2 prerequisites](https://v2.tauri.app/start/prerequisites/) を参照してください。
+Node.js ^22.13.0 || >=24.0.0 と Rust stable を追加し、X11／Wayland session でSkillを実行します。他のdistributionは [Tauri 2 prerequisites](https://v2.tauri.app/start/prerequisites/) を参照してください。
 
 ### Skill コマンド
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -10,14 +10,14 @@
 
 > **プロジェクト状況：** 機能開発は完了し、最後のオプションとして4人のAI-Sister記念Themeと12ラウンドのブレインストーミングpresetを追加しました。ブレインストーミングは4つの交代制の席、合計48発言、同一sessionの全履歴を維持します。組み込みの4役または4席のpresetはすべて、ChatGPT、Claude、Gemini、Grokを1回ずつ割り当てます。今後はprovider互換性、セキュリティ、build障害のみを保守し、既存のsnapshot／replayは拡張しません。
 
-## v1.8.0 の更新点
+## v1.8.1 の更新点
 
-- **会話を全幅表示。** ヘッダーから会話workspaceを最大化または復元でき、実行中workflowを止めずにsidebarとresizerの操作を完全に隔離します。
-- **読んでいるproviderを追跡。** Transcriptのreading lineに対応するprovider chipを表示し、window resizeやtext reflow後も再計算します。
-- **native page遷移を安全化。** Login、preflight、replay、overlay復元を最新provider stateへ統一し、古いWebViewがtranscriptを覆う競合を防ぎます。
-- **長い会話を効率的に追跡。** 有界binary lookupを使用し、最初のprovider messageがreading lineへ到達する前は選択しません。4言語のaccessibility labelも追加しました。
+- **Grok challenge の状態を正確に表示。** Cloudflare／Turnstile widget が元のpage titleを維持していても、automation bridgeを開始したりchallenge pageを変更したりせず、blockedとして報告します。
+- **組み込みの4役設定で4 providerを使用。** ChatGPT、Claude、Gemini、Grokを1回ずつ割り当てます。旧標準設定と完全一致する設定だけを一度移行し、カスタム設定は変更しません。
+- **Snapshot／replay の互換性を保護。** Provider routingを変更したworkflow graphは新しいversionを使用し、互換性のないsnapshotやreplayを暗黙に別routingで実行せず明示的に拒否します。
+- **Source toolchain の安全性を改善。** 対応可能なJavaScript開発依存関係のadvisoryを解消し、Agent-ready source contractはNode.js 22.13.xまたは24+を明示的に要求します。
 
-検証内容、貢献者、記録済みのGTK上流リスク、既知のplatform制限は、日英併記の [`v1.8.0 release notes`](./docs/RELEASE_NOTES_v1.8.0.md) を参照してください。
+検証結果、Grokの制限、残っている手動release gateは、日英併記の [`v1.8.1 release notes`](./docs/RELEASE_NOTES_v1.8.1.md) を参照してください。
 
 ## エディション
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Ask one question, then let your logged-in **ChatGPT, Claude, Gemini, and Grok** 
 - **Accurate Grok challenge status.** A title-preserving Cloudflare/Turnstile widget is reported as blocked without starting the automation bridge or changing the challenge page.
 - **All four providers in built-in four-role setups.** ChatGPT, Claude, Gemini, and Grok are assigned once each; exact legacy defaults migrate once, while customized role maps remain unchanged.
 - **Replay-safe workflow changes.** Updated workflow graphs carry new versions, so incompatible snapshots and replays fail explicitly instead of silently changing provider routing.
-- **A cleaner source toolchain.** Actionable JavaScript development-dependency advisories are cleared, and the Agent-ready source contract now enforces Node.js 22.13.x or 24+.
+- **A cleaner source toolchain.** Actionable JavaScript development-dependency advisories are cleared, and the Agent-ready source contract now enforces Node.js ^22.13.0 || >=24.0.0.
 
 See the bilingual [`v1.8.1 release notes`](./docs/RELEASE_NOTES_v1.8.1.md) for validation evidence, the Grok limitation, and the remaining manual release gates.
 
@@ -109,7 +109,7 @@ If your Claude desktop/browser session is remote, use a local Claude Code sessio
 
 ### Platform prerequisites for source launch
 
-Common: **Node.js 22.13.x or 24+**, pnpm (or Corepack), and the stable Rust toolchain. The commands below are manual prerequisite examples; the Skill only reports missing items and stops.
+Common: **Node.js ^22.13.0 || >=24.0.0**, pnpm (or Corepack), and the stable Rust toolchain. The commands below are manual prerequisite examples; the Skill only reports missing items and stops.
 
 **Windows 10/11**
 
@@ -132,7 +132,7 @@ sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
   libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
 ```
 
-Then install Node.js 22.13.x or 24+, Rust stable, and run the Skill from a graphical X11/Wayland session. Other distributions should follow the [Tauri 2 prerequisites](https://v2.tauri.app/start/prerequisites/).
+Then install Node.js ^22.13.0 || >=24.0.0, Rust stable, and run the Skill from a graphical X11/Wayland session. Other distributions should follow the [Tauri 2 prerequisites](https://v2.tauri.app/start/prerequisites/).
 
 ### Skill lifecycle commands
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Ask one question, then let your logged-in **ChatGPT, Claude, Gemini, and Grok** 
 
 > **Project status:** Feature development is complete. The final optional AI-Sister four-character commemorative theme and its 12-round Brainstorm preset are included; future changes are limited to provider compatibility, security, and build breakage. Brainstorm keeps four rotating seats and 48 contributions with full same-session history. Every built-in four-role or four-seat setup assigns ChatGPT, Claude, Gemini, and Grok once each. The shipped snapshot/replay tools remain available as-is with no further roadmap.
 
-## v1.8.0 highlights
+## v1.8.1 highlights
 
-- **Full-width transcript.** A header control maximizes or restores the conversation workspace, fully isolating the hidden sidebar and resizer without interrupting the running workflow.
-- **Know whose answer you are reading.** Provider chips follow the answer at the transcript reading line and stay accurate after window resizing or text reflow.
-- **Safer native-page transitions.** Login, preflight, replay, and overlay restoration now use the latest provider state so a stale WebView cannot cover the transcript.
-- **Efficient long conversations.** Scroll focus uses bounded binary lookup, does not preselect a provider before its first answer reaches the reading line, and includes accessible labels in all four UI languages.
+- **Accurate Grok challenge status.** A title-preserving Cloudflare/Turnstile widget is reported as blocked without starting the automation bridge or changing the challenge page.
+- **All four providers in built-in four-role setups.** ChatGPT, Claude, Gemini, and Grok are assigned once each; exact legacy defaults migrate once, while customized role maps remain unchanged.
+- **Replay-safe workflow changes.** Updated workflow graphs carry new versions, so incompatible snapshots and replays fail explicitly instead of silently changing provider routing.
+- **A cleaner source toolchain.** Actionable JavaScript development-dependency advisories are cleared, and the Agent-ready source contract now enforces Node.js 22.13.x or 24+.
 
-See the bilingual [`v1.8.0 release notes`](./docs/RELEASE_NOTES_v1.8.0.md) for validation, contributor credit, the documented upstream GTK risk, and known platform limits.
+See the bilingual [`v1.8.1 release notes`](./docs/RELEASE_NOTES_v1.8.1.md) for validation evidence, the Grok limitation, and the remaining manual release gates.
 
 ## Choose the right edition
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -15,7 +15,7 @@
 - **正確顯示 Grok 驗證狀態。** 即使 Cloudflare／Turnstile widget 保留原本頁面標題，app 仍會回報 blocked，且不啟動自動化 bridge、不修改驗證頁面。
 - **內建四角色配置完整使用四家 provider。** ChatGPT、Claude、Gemini、Grok 各擔任一次；完全符合舊預設的設定只遷移一次，使用者自訂配置則保持不變。
 - **保護 snapshot／replay 相容性。** Provider routing 有變更的 workflow graph 會使用新版號；不相容的 snapshot 或 replay 會明確失敗，不會悄悄改用新路由。
-- **更乾淨的原始碼工具鏈。** 已清除可處理的 JavaScript 開發依賴警示，Agent-ready source contract 現在明確要求 Node.js 22.13.x 或 24+。
+- **更乾淨的原始碼工具鏈。** 已清除可處理的 JavaScript 開發依賴警示，Agent-ready source contract 現在明確要求 Node.js ^22.13.0 || >=24.0.0。
 
 完整驗證證據、Grok 限制與尚待完成的人工發布門檻，請見雙語版 [`v1.8.1 發布說明`](./docs/RELEASE_NOTES_v1.8.1.md)。
 
@@ -109,7 +109,7 @@ Repo Skill 可在 Codex app、CLI 與 IDE 使用。雲端／remote task 可以�
 
 ### 各平台原始碼前置環境
 
-共同需求：**Node.js 22.13.x 或 24+**、pnpm（或 Corepack）與 stable Rust toolchain。以下是人工安裝前置環境的範例；Skill 本身只會指出缺少項目並停止。
+共同需求：**Node.js ^22.13.0 || >=24.0.0**、pnpm（或 Corepack）與 stable Rust toolchain。以下是人工安裝前置環境的範例；Skill 本身只會指出缺少項目並停止。
 
 **Windows 10/11**
 
@@ -132,7 +132,7 @@ sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
   libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
 ```
 
-接著安裝 Node.js 22.13.x 或 24+、Rust stable，並在 X11／Wayland 圖形 session 執行 Skill。其他 distribution 請參考 [Tauri 2 prerequisites](https://v2.tauri.app/start/prerequisites/)。
+接著安裝 Node.js ^22.13.0 || >=24.0.0、Rust stable，並在 X11／Wayland 圖形 session 執行 Skill。其他 distribution 請參考 [Tauri 2 prerequisites](https://v2.tauri.app/start/prerequisites/)。
 
 ### Skill 生命週期指令
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -10,14 +10,14 @@
 
 > **專案狀態：** 功能開發已完成，最後一套可選的 AI-Sister 四角色同框紀念 Theme 與 12 輪「腦力激盪」預設已加入；之後僅維護 provider 相容性、安全問題與 build 失敗。腦力激盪保留四個輪換席位、48 次發言與同一 session 的完整前文。所有內建的四角色或四席預設都會讓 ChatGPT、Claude、Gemini、Grok 各擔任一次。現有 snapshot／replay 會原樣保留且不再擴充。
 
-## v1.8.0 更新重點
+## v1.8.1 更新重點
 
-- **逐字稿可全畫面閱讀。** 標題列可放大或還原對話工作區；放大時完整隔離左側欄與 resizer，但不中斷執行中的 workflow。
-- **隨時知道正在讀哪一家。** Provider chip 會跟隨逐字稿閱讀線，視窗縮放或文字重排後也會重新計算。
-- **原生頁面切換更安全。** 登入、preflight、replay 與 overlay 還原統一依最新 provider 狀態處理，避免舊 WebView 蓋住逐字稿。
-- **長對話捲動更有效率。** 閱讀位置使用有界 binary lookup；第一則 provider 訊息尚未到達閱讀線前不會提早標示，並提供四語可及性標籤。
+- **正確顯示 Grok 驗證狀態。** 即使 Cloudflare／Turnstile widget 保留原本頁面標題，app 仍會回報 blocked，且不啟動自動化 bridge、不修改驗證頁面。
+- **內建四角色配置完整使用四家 provider。** ChatGPT、Claude、Gemini、Grok 各擔任一次；完全符合舊預設的設定只遷移一次，使用者自訂配置則保持不變。
+- **保護 snapshot／replay 相容性。** Provider routing 有變更的 workflow graph 會使用新版號；不相容的 snapshot 或 replay 會明確失敗，不會悄悄改用新路由。
+- **更乾淨的原始碼工具鏈。** 已清除可處理的 JavaScript 開發依賴警示，Agent-ready source contract 現在明確要求 Node.js 22.13.x 或 24+。
 
-完整驗證、貢獻者 credit、已記錄的 GTK 上游風險與平台限制，請見雙語版 [`v1.8.0 發布說明`](./docs/RELEASE_NOTES_v1.8.0.md)。
+完整驗證證據、Grok 限制與尚待完成的人工發布門檻，請見雙語版 [`v1.8.1 發布說明`](./docs/RELEASE_NOTES_v1.8.1.md)。
 
 ## 選擇適合的版本
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Compatibility and Smoke-Test Matrix / 相容性與人工測試矩陣
 
-> Last reviewed: 2026-07-27 for v1.8.0. This document records evidence, not a guarantee. Provider DOM and login flows can change without notice.
+> Last reviewed: 2026-07-27 for the v1.8.1 release candidate. This document records evidence, not a guarantee. Provider DOM and login flows can change without notice.
 
 ## Status legend
 
@@ -23,13 +23,15 @@ macOS remains ad-hoc signed, not Developer ID signed or notarized. The Apple Sil
 
 | Evidence | Windows | macOS / Linux | Status |
 |---|---|---|---|
-| Manifest/schema and Skill drift tests | 20 focused tests pass locally | The same 20 tests pass in Windows, macOS, and Linux CI jobs | **Verified** as a source contract; GUI launch remains separate |
+| Manifest/schema and Skill drift tests | 22 focused tests pass locally | The same 22 tests pass in Windows, macOS, and Linux CI jobs | **Verified** as a source contract; GUI launch remains separate |
 | Doctor/audit/dry-run JSON | Exercised locally; dry-run preserves runtime state | Node contract paths pass on all three CI operating systems | Windows **Verified**; others **CI-only** |
 | App-level READY wait | Three live source-launch smokes reached the same-run, identity-verified control-pane READY marker on 2026-07-12; stale/replacement/missing-state tests also pass | No real-device source-launch report | Windows **Verified**; others **Pending** |
 | Launch/stop race safety | Live smokes released the fail-closed launch mutex; audit probes detected generated/target/runtime changes; stop re-verified before kill and before same-run state deletion; foreign/EPERM tests pass | Same code path, not manually exercised | Windows **Verified**; others **Pending** |
 | Corrupt state recovery | Default stop refused malformed state and preserved it; explicit `--clear-invalid-state` removed only the state file, then a normal launch/stop completed | Not manually exercised | Windows **Verified**; others **Pending** |
 
 The Agent contract does not claim that CI displayed a window. It also does not install host prerequisites, inventory the full OS, sandbox checked-out code, upload receipts, or roll back host changes. See [`AGENT-READY-SOURCE-RELEASE.md`](./AGENT-READY-SOURCE-RELEASE.md).
+
+The v2.0.0 source contract supports Node.js `^22.13.0 || >=24.0.0`, matching the locked pnpm and lint toolchain. `agent:doctor` rejects unsupported Node versions and stops instead of presenting an invalid source launch as ready. This requirement applies only to source development; packaged desktop users do not need Node.js.
 
 ## Provider adapters
 
@@ -38,7 +40,7 @@ The Agent contract does not claim that CI displayed a window. It also does not i
 | ChatGPT | v6 | v4 text workflow **Verified**; v5 mismatch recovery and v6 logged-out precedence have automated coverage and await live retest | Partial manual coverage; recheck after provider UI changes |
 | Claude | v4 | v3 text workflow **Verified**; v4 login-page detection and explicit Google SSO scope have automated coverage and await live retest | Not a compatibility claim |
 | Gemini | v2 | Base text workflow **Verified**; bounded Google `/sorry` navigation, blocked status, and passive bridge behavior have automated coverage and await live retest | Not a compatibility claim |
-| Grok | v7 | Base text workflow **Verified**; localized logged-out precedence has automated coverage and awaits live retest | Not a compatibility claim |
+| Grok | v7 | Base text workflow **Verified**; localized logged-out precedence and title-preserving Cloudflare/Turnstile blocked-state detection have automated coverage and await live retest | Not a compatibility claim |
 
 Automated tests validate adapter structure, schema v1/v2 parser compatibility, typed detector rejection, logged-out precedence, approved strategies, HTTPS URL parsing, and navigation boundaries. They do not log into live provider accounts. Remote adapter updates cannot expand the URL scopes bundled with the installed app.
 

--- a/docs/RELEASE_NOTES_v1.8.1.md
+++ b/docs/RELEASE_NOTES_v1.8.1.md
@@ -1,0 +1,70 @@
+# v1.8.1 — Accurate Grok challenge status and four-provider defaults
+
+## Stable maintenance release / 正式維護版本
+
+Multi-AI Chat Desktop `v1.8.1` is a focused provider-compatibility and source-security maintenance release. It reports title-preserving Grok Cloudflare/Turnstile challenges accurately, restores all four providers to every built-in four-role or four-seat setup, protects snapshot/replay compatibility, and clears actionable JavaScript development-dependency advisories.
+
+Multi-AI Chat Desktop `v1.8.1` 是聚焦於 provider 相容性與原始碼安全的維護版本。本版可正確回報保留原頁面標題的 Grok Cloudflare／Turnstile 驗證、讓所有內建四角色或四席配置重新完整使用四家 provider、保護 snapshot／replay 相容性，並清除可處理的 JavaScript 開發依賴警示。
+
+## Accurate Grok challenge reporting / 正確回報 Grok 安全驗證
+
+- A Grok-only, bounded, read-only host probe detects known embedded Turnstile markers even when the top-level page title remains `Grok`.
+- Grok 專用、有界且唯讀的 host probe，即使頂層頁面標題仍為 `Grok`，也能辨識已知的內嵌 Turnstile 標記。
+- Detection runs only while the automation bridge is absent, does not mutate the provider document, and rejects stale probe results before reporting the provider as blocked.
+- 偵測只會在 automation bridge 尚未存在時執行，不會修改 provider document，且會拒絕過期的 probe 結果，再把 provider 回報為 blocked。
+- This resolves the actionable status-reporting portion of [#53](https://github.com/teddashh/multi-ai-chat-desktop/issues/53). It does not bypass Turnstile or make a system-browser login authenticate the app's isolated WebView profile.
+- 這解決了 [#53](https://github.com/teddashh/multi-ai-chat-desktop/issues/53) 中可處理的狀態回報問題；它不會繞過 Turnstile，也不會讓系統瀏覽器登入替 app 內隔離的 WebView profile 完成驗證。
+
+## Restored four-provider defaults / 恢復四家 provider 預設
+
+- Debate, Consult, Coding, Roundtable, and Brainstorm now assign ChatGPT, Claude, Gemini, and Grok once each in their built-in four-role or four-seat configurations.
+- 四方辯證、多方諮詢、Coding、道理辯證與腦力激盪的內建四角色／四席配置，現在都會讓 ChatGPT、Claude、Gemini、Grok 各擔任一次。
+- Exact v1.7–v1.8 three-provider defaults are upgraded once through the versioned settings migration. User-customized role maps remain unchanged.
+- 完全符合 v1.7–v1.8 三家 provider 舊預設的設定，會透過有版本的 settings migration 遷移一次；使用者自訂的角色配置保持不變。
+- If Grok or another provider is unavailable, structured workflows stop at preflight and identify the unavailable provider. Users can complete login inside the app WebView or reassign the affected role.
+- 若 Grok 或其他 provider 無法使用，結構化 workflow 會在 preflight 停止並指出無法使用的 provider；使用者可在 app WebView 內完成登入，或重新指定受影響的角色。
+- Workflow graph versions were increased wherever default provider routing changed, preserving explicit snapshot/replay mismatch handling.
+- 所有預設 provider routing 有變更的 workflow graph 都提高了版本，讓 snapshot／replay 的不相容情況維持明確失敗。
+
+## Source-toolchain security / 原始碼工具鏈安全
+
+- ESLint, React Hooks linting, PostCSS, and their locked transitive dependency graph were updated, clearing the actionable `brace-expansion`, `fast-uri`, and `postcss` advisories.
+- ESLint、React Hooks linting、PostCSS 與鎖定的 transitive dependency graph 已更新，清除可處理的 `brace-expansion`、`fast-uri` 與 `postcss` advisories。
+- The existing lint policy remains in force; the dependency refresh does not silently enable optional React Compiler rules or change packaged application behavior.
+- 現有 lint policy 保持不變；這次依賴更新不會暗中啟用可選的 React Compiler rules，也不會改變封裝後 app 的行為。
+- The Agent-ready source contract and Skills move to v2.0.0 and require Node.js `^22.13.0 || >=24.0.0`, matching the supported intersection of the locked source toolchain. Packaged users are unaffected.
+- Agent-ready source contract 與 Skills 升級到 v2.0.0，並要求 Node.js `^22.13.0 || >=24.0.0`，與鎖定工具鏈實際支援的交集一致；封裝版使用者不受影響。
+
+## Validation / 驗證
+
+- The release candidate passes 448 frontend tests across 52 files, 22 Agent contract tests, TypeScript type-checking, ESLint, adapter schema/seed checks, production injected-script builds, and the production frontend build.
+- Release candidate 通過 52 個檔案共 448 個 frontend tests、22 個 Agent contract tests、TypeScript type-check、ESLint、adapter schema／seed checks、production injected-script build 與 production frontend build。
+- `pnpm audit --audit-level=low` reports no known JavaScript dependency vulnerabilities.
+- `pnpm audit --audit-level=low` 未發現已知的 JavaScript dependency 漏洞。
+- It also passes 63 Rust tests, `cargo fmt --check`, warnings-denied Clippy, and pull-request checks on Windows, macOS, and Linux.
+- 同時通過 63 個 Rust tests、`cargo fmt --check`、warnings-denied Clippy，以及 Windows、macOS、Linux 的 pull-request checks。
+- The immutable `v1.8.1` tag rebuilds the Windows installer and portable zip, Apple Silicon DMG, and Linux AppImage before the draft release is reviewed.
+- Immutable `v1.8.1` tag 會重新建置 Windows installer／portable zip、Apple Silicon DMG 與 Linux AppImage，完成後再檢查 Draft Release。
+
+## Downloads / 下載
+
+- Windows x64 installer and portable zip
+- Apple Silicon macOS DMG
+- Linux x86_64 AppImage
+
+## Release gate and known limits / 發布門檻與已知限制
+
+- Automated tests verify challenge detection policy; they do not execute or prove completion of a live third-party Turnstile challenge.
+- 自動化測試可驗證 challenge detection policy，但不會實際完成第三方 Turnstile，也不能證明 live challenge 可通過。
+- Stable publication still requires a Windows artifact smoke test and, on Apple Silicon, first launch plus login checks for all four providers—especially confirmation that Grok leaves Cloudflare verification. Artifact creation or CI packaging alone is not that evidence.
+- 正式發布仍需完成 Windows artifact smoke test；Apple Silicon 則需驗證首次啟動與四家 provider 登入，尤其必須確認 Grok 能離開 Cloudflare 驗證頁。只有產生 artifact 或通過 CI 封裝不算這項證據。
+- Windows artifacts remain unsigned and may trigger SmartScreen.
+- Windows 產物仍未簽章，可能觸發 SmartScreen。
+- The macOS package is ad-hoc signed and signature-verified in CI, but is not Apple-notarized.
+- macOS package 使用 ad-hoc 簽章並由 CI 驗證，但尚未 Apple notarize。
+- Linux remains CI-packaged without a new maintainer-owned real-device launch report.
+- Linux 仍由 CI 封裝，沒有 maintainer 自有實機的最新啟動回報。
+- The current Tauri/Wry Linux GTK3 dependency graph retains the documented medium-severity `glib::VariantStrIter` advisory. The app does not directly call the affected API, and this release does not represent that upstream risk as fixed.
+- 目前 Tauri／Wry 的 Linux GTK3 dependency graph 仍保留已記錄的 medium-severity `glib::VariantStrIter` advisory；本 app 未直接呼叫受影響 API，本版也不會把這項上游風險宣稱為已修復。
+
+**Full changelog:** https://github.com/teddashh/multi-ai-chat-desktop/compare/v1.8.0...v1.8.1

--- a/docs/RUN-AND-UPDATE.md
+++ b/docs/RUN-AND-UPDATE.md
@@ -4,7 +4,7 @@
 
 ## 前置需求
 
-- Node.js 22.13.x 或 24+
+- Node.js ^22.13.0 || >=24.0.0
 - pnpm（本專案鎖定 `pnpm@11`，可用 Corepack：`corepack enable`）
 - Rust stable toolchain（Windows 需 MSVC + Visual Studio Build Tools「Desktop development with C++」）
 - Windows 10/11 通常已內建 WebView2

--- a/scripts/agent/tests/manifest.test.mjs
+++ b/scripts/agent/tests/manifest.test.mjs
@@ -76,7 +76,7 @@ test('all localized READMEs expose the same Agent contract boundary', () => {
     assert.match(source, /AGENT-READY-SOURCE-RELEASE\.md/);
     assert.match(source, /launch\.mjs --wait --timeout-ms 600000 --json/);
     assert.match(source, /Docker/i);
-    assert.match(source, /Node\.js 22\.13\.x.*24\+/);
+    assert.equal(source.includes(`Node.js ${supportedNodeRange}`), true);
   }
 });
 


### PR DESCRIPTION
## Summary

- Add bilingual v1.8.1 release notes covering accurate Grok challenge status, restored four-provider defaults, replay-safe graph versions, and the source-toolchain security refresh.
- Update the four localized README highlight sections and links for v1.8.1.
- Refresh compatibility evidence for the 22-test Agent source contract and Grok's title-preserving blocked-state coverage.
- Express the source Node requirement consistently as the exact supported range, `^22.13.0 || >=24.0.0`, and keep the README drift test aligned.
- Keep the frozen specification/plan/architecture and historical release notes unchanged; runtime package versions remain tag-injected.

## Release evidence

- `pnpm verify` — 52 Vitest files / 448 tests, 22 Agent contract tests, typecheck, ESLint, injected build, and adapter checks passed on the current head.
- `pnpm build` — production frontend build passed.
- `pnpm audit --audit-level=low` — no known vulnerabilities; Dependabot alert #8 is fixed on `main`.
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 63 passed.
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` — passed.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` — passed.
- `node scripts/agent/launch.mjs --dry-run --json` — contract 2.0.0 prerequisites passed and no writes were performed.

## Publication boundary

This PR prepares the immutable `v1.8.1` tag and draft artifacts; it does not claim the stable publication gate is complete. Stable publication still requires Windows installer/portable smoke testing and Apple Silicon first launch plus all four provider login checks, especially proof that Grok exits Cloudflare verification. Linux may remain CI-only under the documented policy.