### PR TITLE
fix(grok): defer bridge until Turnstile clears

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Compatibility and Smoke-Test Matrix / 相容性與人工測試矩陣
 
-> Last reviewed: 2026-07-28 for the v1.8.1 release candidate. This document records evidence, not a guarantee. Provider DOM and login flows can change without notice.
+> Last reviewed: 2026-07-28 for unreleased maintenance after v1.8.1. This document records evidence, not a guarantee. Provider DOM and login flows can change without notice.
 
 ## Status legend
 
@@ -40,13 +40,13 @@ The v2.0.0 source contract supports Node.js `^22.13.0 || >=24.0.0`, matching the
 | ChatGPT | v6 | v4 text workflow **Verified**; v5 mismatch recovery and v6 logged-out precedence have automated coverage and await live retest | Partial manual coverage; recheck after provider UI changes |
 | Claude | v4 | v3 text workflow **Verified**; v4 login-page detection and explicit Google SSO scope have automated coverage and await live retest | Not a compatibility claim |
 | Gemini | v2 | Base text workflow **Verified**; bounded Google `/sorry` navigation, blocked status, and passive bridge behavior have automated coverage and await live retest | Not a compatibility claim |
-| Grok | v7 | Base text workflow **Verified**; a Windows 11 / WebView2 150 fresh-profile prototype completed Turnstile and embedded login; delayed status handoff has automated coverage and awaits a live retest | Not a compatibility claim |
+| Grok | v7 | Base text workflow **Verified**; a Windows 11 / WebView2 150 fresh-profile prototype completed Turnstile and embedded login; challenge-first delayed handoff, watchdog recovery, and mutation refusal have automated coverage and await a live retest | Not a compatibility claim |
 
 Automated tests validate adapter structure, schema v1/v2 parser compatibility, typed detector rejection, logged-out precedence, approved strategies, HTTPS URL parsing, and navigation boundaries. They do not log into live provider accounts. Remote adapter updates cannot expand the URL scopes bundled with the installed app.
 
 Claude's current consumer web experience requires an authenticated account. Adapter v4 recognizes common email-login fields and keeps the official Anthropic and Google sign-in routes within the existing bounded SSO policy. The app does not bypass login, age, subscription, challenge, or other provider-side requirements; guided workflows that assign a Claude seat remain blocked until Claude reports a ready composer.
 
-macOS note: the `v1.0.1` report verified ChatGPT, Claude, and Gemini login, but Grok remained on Cloudflare's security-verification page. Current source does not apply a document-start bridge or automation-oriented browser arguments to Grok. It installs the bridge only after a read-only probe explicitly confirms that no Cloudflare or hCaptcha marker is present on an allowlisted Grok app page. Known challenge titles still report a blocked state, including the Traditional Chinese `安全驗證` variant. A Windows 11 test with WebView2 Runtime `150.0.4078.99` completed the live challenge and embedded login using the prototype; the final status handoff and non-Windows behavior still require live confirmation. The app does not automate or bypass the challenge.
+macOS note: the `v1.0.1` report verified ChatGPT, Claude, and Gemini login, but Grok remained on Cloudflare's security-verification page. Current source omits the document-start bridge and permission shim for Grok while retaining the background-liveness settings required by hidden provider panes. A single atomic driver reads the shared Cloudflare/hCaptcha title, body, and marker signals before changing provider state or creating the bridge, then retries unresolved and blocked documents through page-load events and the host watchdog. Known challenge titles include the Traditional Chinese `安全驗證` variant, and an already-running engine refuses fill, send, and stop mutations while a challenge is active. A Windows 11 test with WebView2 Runtime `150.0.4078.99` completed the live challenge and embedded login using a broader prototype configuration; the final isolated configuration, status handoff, and non-Windows behavior still require live confirmation. The app does not automate or bypass the challenge.
 
 Gemini may redirect an embedded session to `https://www.google.com/sorry/index?...`. Current source allows only the HTTPS `www.google.com/sorry` path family for Gemini, reports it as blocked instead of logged in, skips the permission shim there, and defers bridge startup until Google returns to Gemini. Sibling paths, lookalike hosts, non-HTTPS URLs, and cross-provider use remain denied. A live challenge completion still requires manual verification.
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Compatibility and Smoke-Test Matrix / 相容性與人工測試矩陣
 
-> Last reviewed: 2026-07-27 for the v1.8.1 release candidate. This document records evidence, not a guarantee. Provider DOM and login flows can change without notice.
+> Last reviewed: 2026-07-28 for the v1.8.1 release candidate. This document records evidence, not a guarantee. Provider DOM and login flows can change without notice.
 
 ## Status legend
 
@@ -40,13 +40,13 @@ The v2.0.0 source contract supports Node.js `^22.13.0 || >=24.0.0`, matching the
 | ChatGPT | v6 | v4 text workflow **Verified**; v5 mismatch recovery and v6 logged-out precedence have automated coverage and await live retest | Partial manual coverage; recheck after provider UI changes |
 | Claude | v4 | v3 text workflow **Verified**; v4 login-page detection and explicit Google SSO scope have automated coverage and await live retest | Not a compatibility claim |
 | Gemini | v2 | Base text workflow **Verified**; bounded Google `/sorry` navigation, blocked status, and passive bridge behavior have automated coverage and await live retest | Not a compatibility claim |
-| Grok | v7 | Base text workflow **Verified**; localized logged-out precedence and title-preserving Cloudflare/Turnstile blocked-state detection have automated coverage and await live retest | Not a compatibility claim |
+| Grok | v7 | Base text workflow **Verified**; a Windows 11 / WebView2 150 fresh-profile prototype completed Turnstile and embedded login; delayed status handoff has automated coverage and awaits a live retest | Not a compatibility claim |
 
 Automated tests validate adapter structure, schema v1/v2 parser compatibility, typed detector rejection, logged-out precedence, approved strategies, HTTPS URL parsing, and navigation boundaries. They do not log into live provider accounts. Remote adapter updates cannot expand the URL scopes bundled with the installed app.
 
 Claude's current consumer web experience requires an authenticated account. Adapter v4 recognizes common email-login fields and keeps the official Anthropic and Google sign-in routes within the existing bounded SSO policy. The app does not bypass login, age, subscription, challenge, or other provider-side requirements; guided workflows that assign a Claude seat remain blocked until Claude reports a ready composer.
 
-macOS note: the `v1.0.1` report verified ChatGPT, Claude, and Gemini login, but Grok remained on Cloudflare's security-verification page. Current source delays bridge startup for every provider until detected Cloudflare or hCaptcha challenge signals disappear and additionally avoids Grok History API replacement, following anti-bot WebView compatibility requirements. Known Grok challenge titles are reported through the native WebView title callback; title-preserving widgets are detected by a Grok-only read-only host probe. This improves user feedback without starting the bridge or mutating the challenge document. CI can verify the policy but cannot prove that a live challenge completes.
+macOS note: the `v1.0.1` report verified ChatGPT, Claude, and Gemini login, but Grok remained on Cloudflare's security-verification page. Current source does not apply a document-start bridge or automation-oriented browser arguments to Grok. It installs the bridge only after a read-only probe explicitly confirms that no Cloudflare or hCaptcha marker is present on an allowlisted Grok app page. Known challenge titles still report a blocked state, including the Traditional Chinese `安全驗證` variant. A Windows 11 test with WebView2 Runtime `150.0.4078.99` completed the live challenge and embedded login using the prototype; the final status handoff and non-Windows behavior still require live confirmation. The app does not automate or bypass the challenge.
 
 Gemini may redirect an embedded session to `https://www.google.com/sorry/index?...`. Current source allows only the HTTPS `www.google.com/sorry` path family for Gemini, reports it as blocked instead of logged in, skips the permission shim there, and defers bridge startup until Google returns to Gemini. Sibling paths, lookalike hosts, non-HTTPS URLs, and cross-provider use remain denied. A live challenge completion still requires manual verification.
 

--- a/injected/challenge.ts
+++ b/injected/challenge.ts
@@ -2,44 +2,20 @@
 // remains passive while a challenge is present; the engine can report a later interstitial as
 // blocked without changing bridge startup policy.
 
-const CHALLENGE_MARKER_SELECTOR =
-  '#challenge-running, #challenge-stage, #cf-challenge-running, form#challenge-form, .h-captcha, [data-hcaptcha-widget-id], iframe[src*="hcaptcha.com"], iframe[src*="challenges.cloudflare.com"]';
+import challengeSignals from '../shared/challenge-signals.json';
 
 export function hasCloudflareChallengeSignals(title: string, bodyText: string, challengeMarker: boolean): boolean {
   if (challengeMarker) return true;
   const normalizedTitle = title.trim().toLocaleLowerCase();
-  const normalizedBody = bodyText.trim().slice(0, 2_000).toLocaleLowerCase();
-  const titleSignals = [
-    'just a moment',
-    'attention required',
-    'security verification',
-    '請稍候',
-    '请稍候',
-    '安全性驗證',
-    '安全验证',
-    'セキュリティ検証',
-    'sicherheitsüberprüfung',
-  ];
-  const bodySignals = [
-    'verifying you are human',
-    'verify you are human',
-    'performing security verification',
-    'checking if the site connection is secure',
-    'complete the security check',
-    '驗證您是人類',
-    '验证您是人类',
-    '確認您是人類',
-    '正在驗證您是否為真人',
-    '正在執行安全驗證',
-    '正在执行安全验证',
-    '人間であることを確認しています',
-    'sicherheitsüberprüfung',
-  ];
-  return titleSignals.some((signal) => normalizedTitle.includes(signal)) || bodySignals.some((signal) => normalizedBody.includes(signal));
+  const normalizedBody = bodyText.trim().slice(0, challengeSignals.bodySampleChars).toLocaleLowerCase();
+  return (
+    challengeSignals.titleSignals.some((signal) => normalizedTitle.includes(signal)) ||
+    challengeSignals.bodySignals.some((signal) => normalizedBody.includes(signal))
+  );
 }
 
 export function isCloudflareChallengeActive(): boolean {
-  if (document.querySelector(CHALLENGE_MARKER_SELECTOR)) return true;
+  if (document.querySelector(challengeSignals.markerSelector)) return true;
   if (hasCloudflareChallengeSignals(document.title ?? '', '', false)) return true;
   return hasCloudflareChallengeSignals('', sampleBodyText(), false);
 }
@@ -53,7 +29,7 @@ export function isProviderChallengeActive(provider: string): boolean {
   return isGoogleSorryChallenge(provider, location.hostname, location.pathname) || isCloudflareChallengeActive();
 }
 
-function sampleBodyText(maxChars = 2_000): string {
+function sampleBodyText(maxChars = challengeSignals.bodySampleChars): string {
   if (!document.body) return '';
   const walker = document.createTreeWalker(document.body, 4);
   let sample = '';

--- a/injected/engine.ts
+++ b/injected/engine.ts
@@ -13,6 +13,7 @@ interface DetectorObject {
 }
 
 type Detector = string | DetectorObject;
+type ChallengeMutationGuard = () => void;
 
 interface AdapterConfig {
   provider: AIProvider;
@@ -40,7 +41,7 @@ interface MacEngineState {
   stop?: () => void;
 }
 
-type InputStrategy = (el: Element, text: string) => void | Promise<void>;
+type InputStrategy = (el: Element, text: string, assertCanMutate: ChallengeMutationGuard) => void | Promise<void>;
 
 interface RetryLookupOptions {
   intervalMs?: number;
@@ -124,6 +125,20 @@ class InputInjectionError extends Error {
   }
 }
 
+class ChallengeActiveError extends Error {
+  constructor() {
+    super('security challenge is active');
+    this.name = 'ChallengeActiveError';
+  }
+}
+
+class InactiveSendOperationError extends Error {
+  constructor() {
+    super('send operation is no longer active');
+    this.name = 'InactiveSendOperationError';
+  }
+}
+
 (function engine() {
   if (typeof window === 'undefined') return;
   if (window.self !== window.top) return;
@@ -136,11 +151,17 @@ class InputInjectionError extends Error {
   let adapter: AdapterConfig | undefined;
   let statusInterval: number | undefined;
   let responseTimeout: number | undefined;
+  let finishResponseTimeout: number | undefined;
   let checkDoneInterval: number | undefined;
   let pollInterval: number | undefined;
   let lastSeenResponseEl: Element | null = null;
   let responseBaselineEls = new Set<Element>();
   let waitingForResponse = false;
+  let responseGeneration = 0;
+  let activeResponseGeneration = 0;
+  let nextSendOperation = 0;
+  let activeSendOperation: number | undefined;
+  let draftStaging = false;
   let lastResponseText = '';
   let pendingPromptText = '';
   let lastChunkTime = 0;
@@ -179,13 +200,21 @@ class InputInjectionError extends Error {
       return;
     }
     if (message.action === 'SEND_MESSAGE' && (!adapter || !message.provider || message.provider === adapter.provider)) {
+      const sendOperation = beginSendOperation(message.provider);
+      if (sendOperation === undefined) return;
+      if (abortAutomationForChallenge(message.provider, true, 'send', sendOperation)) return;
       const payload = message.payload as { text?: string } | undefined;
-      void sendMessage(payload?.text ?? '', message.provider);
+      void sendMessage(payload?.text ?? '', message.provider, sendOperation);
       return;
     }
     if (message.action === 'FILL_DRAFT' && (!adapter || !message.provider || message.provider === adapter.provider)) {
+      if (!beginFillOperation(message.provider)) return;
+      if (abortAutomationForChallenge(message.provider, false, 'fill')) {
+        releaseFillOperation();
+        return;
+      }
       const payload = message.payload as { text?: string } | undefined;
-      void fillDraft(payload?.text ?? '', message.provider);
+      void fillDraft(payload?.text ?? '', message.provider).finally(releaseFillOperation);
       return;
     }
     if (message.action === 'CHECK_STATUS') {
@@ -214,6 +243,7 @@ class InputInjectionError extends Error {
 
   function stop() {
     if (!adapter) return;
+    if (abortAutomationForChallenge(adapter.provider, false, 'stop')) return;
     try {
       const button = queryFirst(adapter.stopButtonSelectors ?? []);
       (button as HTMLElement | null)?.click?.();
@@ -245,13 +275,13 @@ class InputInjectionError extends Error {
       return;
     }
     let login: 'logged_in' | 'logged_out' | 'blocked' = 'logged_out';
-    if (hasDetector(adapter.loggedOutDetectors)) {
+    if (isProviderChallengeActive(adapter.provider)) {
+      login = 'blocked';
+    } else if (hasDetector(adapter.loggedOutDetectors)) {
       login = 'logged_out';
     } else if (hasDetector(adapter.loginDetectors)) {
       login = 'logged_in';
     } else if (adapter.provider === 'gemini' && location.hostname === 'gemini.google.com') {
-      login = 'blocked';
-    } else if (isProviderChallengeActive(adapter.provider)) {
       login = 'blocked';
     }
     bridge.emit({
@@ -262,78 +292,205 @@ class InputInjectionError extends Error {
     });
   }
 
+  function reportChallengeBlocked(provider: AIProvider) {
+    bridge.emit({
+      v: 1,
+      action: 'STATUS_REPORT',
+      provider,
+      payload: { dom: 'ready', login: 'blocked', thinking: false, bootId: bridge.bootId },
+    });
+  }
+
+  function abortAutomationForChallenge(
+    providerHint: AIProvider | undefined,
+    errorAsDone: boolean,
+    operation: 'send' | 'fill' | 'stop',
+    sendOperation?: number,
+  ): boolean {
+    const provider = providerHint ?? adapter?.provider;
+    if (!provider || !isProviderChallengeActive(provider)) return false;
+    reportChallengeBlocked(provider);
+    logEngine(`${provider} ${operation} refused: security challenge is active`);
+    if (errorAsDone) doneWithError(`${provider} security challenge is active`, provider, sendOperation);
+    return true;
+  }
+
+  function beginSendOperation(providerHint?: AIProvider): number | undefined {
+    if (activeSendOperation !== undefined || draftStaging || waitingForResponse) {
+      logEngine(`${providerHint ?? adapter?.provider ?? 'provider'} send rejected: response in flight`);
+      return undefined;
+    }
+    nextSendOperation += 1;
+    activeSendOperation = nextSendOperation;
+    return nextSendOperation;
+  }
+
+  function beginFillOperation(providerHint?: AIProvider): boolean {
+    if (activeSendOperation !== undefined || draftStaging || waitingForResponse) {
+      logEngine(`${providerHint ?? adapter?.provider ?? 'provider'} fill rejected: response in flight`);
+      return false;
+    }
+    draftStaging = true;
+    return true;
+  }
+
+  function releaseFillOperation() {
+    void Promise.resolve().then(() => {
+      draftStaging = false;
+    });
+  }
+
+  function isActiveSendOperation(sendOperation: number): boolean {
+    return activeSendOperation === sendOperation;
+  }
+
+  function releaseSendOperation(sendOperation: number) {
+    void Promise.resolve().then(() => {
+      if (activeSendOperation === sendOperation && !waitingForResponse) {
+        activeSendOperation = undefined;
+      }
+    });
+  }
+
   async function stageDraftForResponse(
     text: string,
     providerHint?: AIProvider,
+    challengeErrorAsDone = true,
+    sendOperation?: number,
   ): Promise<{ activeAdapter: AdapterConfig; input: Element; injectionStartedAt: number } | undefined> {
+    if (sendOperation !== undefined && !isActiveSendOperation(sendOperation)) return undefined;
+    if (
+      abortAutomationForChallenge(
+        providerHint,
+        challengeErrorAsDone,
+        challengeErrorAsDone ? 'send' : 'fill',
+        sendOperation,
+      )
+    ) {
+      return undefined;
+    }
     const activeAdapter = adapter;
     if (!activeAdapter) {
-      doneWithError('adapter not installed', providerHint);
+      doneWithError('adapter not installed', providerHint, sendOperation);
       return undefined;
     }
     const input = await retryLookup(() => queryFirst(activeAdapter.inputSelectors), {
       intervalMs: SELECTOR_RETRY_INTERVAL_MS,
       timeoutMs: INPUT_SELECTOR_TIMEOUT_MS,
     });
+    if (sendOperation !== undefined && !isActiveSendOperation(sendOperation)) return undefined;
     if (!input) {
-      doneWithError(`${activeAdapter.provider} input element not found`, activeAdapter.provider);
+      doneWithError(`${activeAdapter.provider} input element not found`, activeAdapter.provider, sendOperation);
+      return undefined;
+    }
+    if (
+      abortAutomationForChallenge(
+        activeAdapter.provider,
+        challengeErrorAsDone,
+        challengeErrorAsDone ? 'send' : 'fill',
+        sendOperation,
+      )
+    ) {
       return undefined;
     }
 
     const existingResponses = document.querySelectorAll(activeAdapter.responseSelectors.join(', '));
     lastSeenResponseEl = existingResponses.length > 0 ? existingResponses[existingResponses.length - 1] : null;
     responseBaselineEls = new Set(existingResponses);
+    responseGeneration += 1;
+    activeResponseGeneration = responseGeneration;
     waitingForResponse = true;
     lastResponseText = '';
     pendingPromptText = text;
     startResponsePolling();
 
     const injectionStartedAt = Date.now();
+    const operation = challengeErrorAsDone ? 'send' : 'fill';
+    const assertCanMutate = () => {
+      if (sendOperation !== undefined && !isActiveSendOperation(sendOperation)) {
+        throw new InactiveSendOperationError();
+      }
+      if (
+        abortAutomationForChallenge(
+          activeAdapter.provider,
+          challengeErrorAsDone,
+          operation,
+          sendOperation,
+        )
+      ) {
+        throw new ChallengeActiveError();
+      }
+    };
     try {
-      await inputStrategies[activeAdapter.inputStrategy](input, text);
+      assertCanMutate();
+      await inputStrategies[activeAdapter.inputStrategy](input, text, assertCanMutate);
+      assertCanMutate();
       assertInputLanded(input, text, activeAdapter.inputStrategy);
     } catch (error) {
-      doneWithError(`${activeAdapter.provider} input injection failed: ${errorMessage(error)}`, activeAdapter.provider);
+      if (error instanceof ChallengeActiveError) {
+        if (!challengeErrorAsDone) cancelResponseWait();
+        return undefined;
+      }
+      if (error instanceof InactiveSendOperationError) {
+        return undefined;
+      }
+      doneWithError(
+        `${activeAdapter.provider} input injection failed: ${errorMessage(error)}`,
+        activeAdapter.provider,
+        sendOperation,
+      );
       return undefined;
     }
 
     return { activeAdapter, input, injectionStartedAt };
   }
 
-  async function sendMessage(text: string, providerHint?: AIProvider) {
-    const staged = await stageDraftForResponse(text, providerHint);
+  async function sendMessage(text: string, providerHint: AIProvider | undefined, sendOperation: number) {
+    const staged = await stageDraftForResponse(text, providerHint, true, sendOperation);
     if (!staged) return;
+    if (!isActiveSendOperation(sendOperation)) return;
     const { activeAdapter, input, injectionStartedAt } = staged;
 
     const preSendDelayMs = Math.max(0, PRE_SEND_DELAY_MS - (Date.now() - injectionStartedAt));
     window.setTimeout(() => {
       void (async () => {
-        const firstAttempt = await activateSend(input);
+        if (!isActiveSendOperation(sendOperation) || !waitingForResponse) return;
+        if (abortAutomationForChallenge(activeAdapter.provider, true, 'send', sendOperation)) return;
+        const firstAttempt = await activateSend(input, sendOperation);
 
+        if (!isActiveSendOperation(sendOperation) || !waitingForResponse) return;
         window.setTimeout(() => {
-          void retrySendIfStillPending(input, firstAttempt, activeAdapter);
+          void retrySendIfStillPending(input, firstAttempt, activeAdapter, sendOperation);
         }, SEND_RETRY_DELAY_MS);
       })();
     }, preSendDelayMs);
   }
 
   async function fillDraft(text: string, providerHint?: AIProvider) {
-    if (waitingForResponse) {
-      logEngine(`${providerHint ?? adapter?.provider ?? 'provider'} fill rejected: response in flight`);
-      return;
-    }
-    const staged = await stageDraftForResponse(text, providerHint);
+    const staged = await stageDraftForResponse(text, providerHint, false);
     if (!staged) return;
     logEngine(`${staged.activeAdapter.provider} fill: draft staged, awaiting native send`);
   }
 
-  async function retrySendIfStillPending(originalInput: Element, firstAttempt: SendActivationResult, originalAdapter: AdapterConfig) {
-    if (!waitingForResponse || !adapter) return;
+  async function retrySendIfStillPending(
+    originalInput: Element,
+    firstAttempt: SendActivationResult,
+    originalAdapter: AdapterConfig,
+    sendOperation: number,
+  ) {
+    if (!isActiveSendOperation(sendOperation) || !waitingForResponse || !adapter) return;
+    if (abortAutomationForChallenge(originalAdapter.provider, true, 'send', sendOperation)) return;
     if (sendStarted(adapter)) return;
 
     const currentInput = queryFirst(adapter.inputSelectors);
     if (!currentInput) {
-      if (!firstAttempt.ok) doneWithError(`${originalAdapter.provider} input disappeared before send was confirmed`, originalAdapter.provider);
+      if (!firstAttempt.ok) {
+        doneWithError(
+          `${originalAdapter.provider} input disappeared before send was confirmed`,
+          originalAdapter.provider,
+          sendOperation,
+        );
+      }
       return;
     }
     const inputText = getInputText(currentInput).trim();
@@ -345,24 +502,38 @@ class InputInjectionError extends Error {
     }
 
     const retryInput = currentInput ?? originalInput;
-    const retryAttempt = await activateSend(retryInput);
+    const retryAttempt = await activateSend(retryInput, sendOperation);
+    if (!isActiveSendOperation(sendOperation) || !waitingForResponse) return;
 
     if (!retryAttempt.ok) {
       doneWithError(
         `${originalAdapter.provider} send activation failed: ${retryAttempt.detail ?? firstAttempt.detail ?? retryAttempt.path}`,
         originalAdapter.provider,
+        sendOperation,
       );
       return;
     }
 
     window.setTimeout(() => {
-      void verifySendAfterRetry(retryAttempt, originalAdapter);
+      void verifySendAfterRetry(retryAttempt, originalAdapter, sendOperation);
     }, SEND_FINAL_VERIFY_DELAY_MS);
   }
 
-  async function verifySendAfterRetry(retryAttempt: SendActivationResult, originalAdapter: AdapterConfig) {
+  async function verifySendAfterRetry(
+    retryAttempt: SendActivationResult,
+    originalAdapter: AdapterConfig,
+    sendOperation: number,
+  ) {
     const activeAdapter = adapter;
-    if (!waitingForResponse || !activeAdapter || activeAdapter.provider !== originalAdapter.provider) return;
+    if (
+      !isActiveSendOperation(sendOperation) ||
+      !waitingForResponse ||
+      !activeAdapter ||
+      activeAdapter.provider !== originalAdapter.provider
+    ) {
+      return;
+    }
+    if (abortAutomationForChallenge(activeAdapter.provider, true, 'send', sendOperation)) return;
     if (sendStarted(activeAdapter)) return;
 
     const currentInput = queryFirst(activeAdapter.inputSelectors);
@@ -372,32 +543,61 @@ class InputInjectionError extends Error {
     if (retryAttempt.path === 'button-click' && (!sendButton || isDisabled(sendButton))) return;
     const hadSendButton = Boolean(sendButton);
 
+    if (abortAutomationForChallenge(activeAdapter.provider, true, 'send', sendOperation)) return;
     const enterOk = dispatchEnter(currentInput);
     logEngine(`${activeAdapter.provider} final send fallback: enter-key${enterOk ? '' : ' failed'}`);
     if (!enterOk) {
-      doneWithError(`${activeAdapter.provider} send activation failed: enter key dispatch failed`, activeAdapter.provider);
+      doneWithError(
+        `${activeAdapter.provider} send activation failed: enter key dispatch failed`,
+        activeAdapter.provider,
+        sendOperation,
+      );
       return;
     }
 
     window.setTimeout(() => {
-      if (!waitingForResponse || !adapter || adapter.provider !== originalAdapter.provider) return;
+      if (
+        !isActiveSendOperation(sendOperation) ||
+        !waitingForResponse ||
+        !adapter ||
+        adapter.provider !== originalAdapter.provider
+      ) {
+        return;
+      }
+      if (abortAutomationForChallenge(adapter.provider, true, 'send', sendOperation)) return;
       if (sendStarted(adapter)) return;
       const finalInput = queryFirst(adapter.inputSelectors);
       const finalButton = finalInput ? querySendButton(adapter, finalInput) : null;
       if (!finalInput || !getInputText(finalInput).trim()) return;
       if (hadSendButton && (!finalButton || isDisabled(finalButton))) return;
-      doneWithError(`${adapter.provider} send was not accepted; draft is still in composer`, adapter.provider);
+      doneWithError(
+        `${adapter.provider} send was not accepted; draft is still in composer`,
+        adapter.provider,
+        sendOperation,
+      );
     }, SEND_FINAL_VERIFY_DELAY_MS);
   }
 
-  async function activateSend(input: Element): Promise<SendActivationResult> {
+  async function activateSend(input: Element, sendOperation: number): Promise<SendActivationResult> {
+    if (!isActiveSendOperation(sendOperation)) {
+      return { ok: false, path: 'enter-key', detail: 'send operation is no longer active' };
+    }
     const activeAdapter = adapter;
     if (!activeAdapter) return { ok: false, path: 'enter-key', detail: 'adapter not installed' };
+    if (abortAutomationForChallenge(activeAdapter.provider, true, 'send', sendOperation)) {
+      return { ok: false, path: 'enter-key', detail: 'security challenge is active' };
+    }
     if (activeAdapter.sendStrategy !== 'enter') {
       const sendBtn = await retryLookup(() => querySendButton(activeAdapter, input), {
         intervalMs: SELECTOR_RETRY_INTERVAL_MS,
         timeoutMs: SEND_BUTTON_SELECTOR_TIMEOUT_MS,
       });
+      if (!isActiveSendOperation(sendOperation)) {
+        return { ok: false, path: 'enter-key', detail: 'send operation is no longer active' };
+      }
+      if (abortAutomationForChallenge(activeAdapter.provider, true, 'send', sendOperation)) {
+        return { ok: false, path: 'enter-key', detail: 'security challenge is active' };
+      }
       if (sendBtn) {
         if (isDisabled(sendBtn)) {
           logEngine(`${activeAdapter.provider} send path: send button disabled; falling back to enter`);
@@ -411,21 +611,32 @@ class InputInjectionError extends Error {
       }
     }
 
+    if (!isActiveSendOperation(sendOperation)) {
+      return { ok: false, path: 'enter-key', detail: 'send operation is no longer active' };
+    }
+    if (abortAutomationForChallenge(activeAdapter.provider, true, 'send', sendOperation)) {
+      return { ok: false, path: 'enter-key', detail: 'security challenge is active' };
+    }
     const ok = dispatchEnter(input);
     logEngine(`${activeAdapter.provider} send path: enter-key${ok ? '' : ' failed'}`);
     return { ok, path: 'enter-key', detail: ok ? undefined : 'enter key dispatch failed' };
   }
 
-  function defaultInjectInput(input: Element, text: string) {
+  function defaultInjectInput(input: Element, text: string, assertCanMutate: ChallengeMutationGuard) {
     const el = input as HTMLElement;
+    assertCanMutate();
     tryFocus(el, 'default input');
+    assertCanMutate();
 
     if (input instanceof HTMLTextAreaElement) {
       const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')?.set;
       if (setter) setter.call(input, text);
       else input.value = text;
+      assertCanMutate();
       input.dispatchEvent(new Event('input', { bubbles: true }));
+      assertCanMutate();
     } else {
+      assertCanMutate();
       try {
         const sel = window.getSelection();
         if (!sel) throw new InputInjectionError('selection unavailable');
@@ -436,17 +647,24 @@ class InputInjectionError extends Error {
       } catch (error) {
         logEngine(`default input selection guard fell back to execCommand: ${errorMessage(error)}`);
       }
-      if (!execInsertText(text)) throw new InputInjectionError('execCommand insertText returned false');
+      assertCanMutate();
+      const inserted = execInsertText(text);
+      assertCanMutate();
+      if (!inserted) throw new InputInjectionError('execCommand insertText returned false');
       el.dispatchEvent(new Event('input', { bubbles: true }));
+      assertCanMutate();
     }
   }
 
-  async function prosemirrorPasteInput(el: Element, text: string) {
+  async function prosemirrorPasteInput(el: Element, text: string, assertCanMutate: ChallengeMutationGuard) {
     const editor = el as HTMLElement;
+    assertCanMutate();
     tryFocus(editor, 'prosemirror editor');
+    assertCanMutate();
 
     try {
       tryFocus(editor, 'prosemirror paste');
+      assertCanMutate();
       const selection = window.getSelection();
       if (!selection) throw new InputInjectionError('selection unavailable');
       const range = document.createRange();
@@ -461,45 +679,63 @@ class InputInjectionError extends Error {
         bubbles: true,
         cancelable: true,
       });
+      assertCanMutate();
       editor.dispatchEvent(pasteEvent);
+      assertCanMutate();
       await Promise.resolve();
+      assertCanMutate();
     } catch (error) {
+      if (error instanceof ChallengeActiveError) throw error;
       logEngine(`prosemirror synthetic paste failed: ${errorMessage(error)}`);
     }
 
+    assertCanMutate();
     if (!composerTextMatches(editor, text)) {
       try {
         tryFocus(editor, 'prosemirror insertText fallback');
+        assertCanMutate();
         const selection = window.getSelection();
         if (!selection) throw new InputInjectionError('selection unavailable');
         const range = document.createRange();
         range.selectNodeContents(editor);
         selection.removeAllRanges();
         selection.addRange(range);
-        if (execInsertText(text)) {
+        assertCanMutate();
+        const inserted = execInsertText(text);
+        assertCanMutate();
+        if (inserted) {
           editor.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: text }));
+          assertCanMutate();
           await Promise.resolve();
+          assertCanMutate();
         }
       } catch (error) {
+        if (error instanceof ChallengeActiveError) throw error;
         logEngine(`prosemirror insertText fallback failed: ${errorMessage(error)}`);
       }
     }
 
+    assertCanMutate();
     if (!composerTextMatches(editor, text)) {
+      assertCanMutate();
       editor.replaceChildren();
       const p = document.createElement('p');
       p.textContent = text;
       editor.appendChild(p);
       editor.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: text }));
+      assertCanMutate();
     }
   }
 
-  async function quillAngularInput(el: Element, text: string) {
+  async function quillAngularInput(el: Element, text: string, assertCanMutate: ChallengeMutationGuard) {
     const editor = el as HTMLElement;
+    assertCanMutate();
     tryFocus(editor, 'quill editor');
+    assertCanMutate();
     // Trusted-Types-safe clear: Gemini enforces Trusted Types (CSP), under which ANY innerHTML
     // assignment — even '' — throws "requires 'TrustedHTML' assignment". replaceChildren() removes
     // all children with no HTML parsing, so it never trips Trusted Types.
+    assertCanMutate();
     editor.replaceChildren();
 
     const lines = text.split('\n');
@@ -511,13 +747,20 @@ class InputInjectionError extends Error {
     }
     editor.appendChild(fragment);
     editor.dispatchEvent(new Event('input', { bubbles: true }));
+    assertCanMutate();
     editor.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: text }));
+    assertCanMutate();
 
     await Promise.resolve();
+    assertCanMutate();
     if (!editor.textContent?.trim()) {
       tryFocus(editor, 'quill fallback');
-      if (!execInsertText(text)) throw new InputInjectionError('quill fallback execCommand insertText returned false');
+      assertCanMutate();
+      const inserted = execInsertText(text);
+      assertCanMutate();
+      if (!inserted) throw new InputInjectionError('quill fallback execCommand insertText returned false');
       editor.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: text }));
+      assertCanMutate();
     }
   }
 
@@ -561,48 +804,62 @@ class InputInjectionError extends Error {
     return hasDetector(adapter?.thinkingDetectors);
   }
 
-  function checkIfDone() {
-    if (!waitingForResponse) return;
+  function checkIfDone(expectedGeneration = activeResponseGeneration) {
+    if (!waitingForResponse || expectedGeneration !== activeResponseGeneration) return;
     if (isThinking()) {
       if (checkDoneInterval === undefined) {
         checkDoneInterval = window.setInterval(() => {
-          if (!waitingForResponse) {
+          if (!waitingForResponse || expectedGeneration !== activeResponseGeneration) {
             clearCheckDone();
             return;
           }
           if (!isThinking()) {
             clearCheckDone();
-            window.setTimeout(() => {
+            finishResponseTimeout = window.setTimeout(() => {
+              finishResponseTimeout = undefined;
+              if (!waitingForResponse || expectedGeneration !== activeResponseGeneration) return;
+              if (isThinking()) {
+                checkIfDone(expectedGeneration);
+                return;
+              }
               const finalText = getLatestResponseText();
               if (finalText) lastResponseText = finalText;
-              finishResponse();
+              finishResponse(expectedGeneration);
             }, timing('doneDelayMs', 3000));
           }
         }, 1000);
       }
       return;
     }
-    finishResponse();
+    finishResponse(expectedGeneration);
   }
 
-  function finishResponse() {
-    if (!waitingForResponse || !adapter) return;
-    waitingForResponse = false;
-    clearTimersForResponse();
-    responseBaselineEls.clear();
+  function finishResponse(expectedGeneration = activeResponseGeneration) {
+    if (!waitingForResponse || expectedGeneration !== activeResponseGeneration || !adapter) return;
     const payload = lastResponseText;
-    pendingPromptText = '';
+    const sendOperation = activeSendOperation;
+    cancelResponseWait();
     bridge.emit({ v: 1, action: 'RESPONSE_DONE', provider: adapter.provider, payload });
+    if (sendOperation !== undefined) releaseSendOperation(sendOperation);
   }
 
-  function doneWithError(reason: string, providerHint?: AIProvider) {
-    const provider = providerHint ?? adapter?.provider;
-    if (!provider) return;
+  function cancelResponseWait() {
     waitingForResponse = false;
     clearTimersForResponse();
     responseBaselineEls.clear();
     pendingPromptText = '';
+  }
+
+  function doneWithError(reason: string, providerHint?: AIProvider, sendOperation?: number) {
+    if (sendOperation !== undefined && !isActiveSendOperation(sendOperation)) return;
+    const provider = providerHint ?? adapter?.provider;
+    if (!provider) {
+      if (sendOperation !== undefined) releaseSendOperation(sendOperation);
+      return;
+    }
+    cancelResponseWait();
     bridge.emit({ v: 1, action: 'RESPONSE_DONE', provider, payload: `[Error: ${reason}]` });
+    if (sendOperation !== undefined) releaseSendOperation(sendOperation);
   }
 
   let observerInstalled = false;
@@ -621,6 +878,7 @@ class InputInjectionError extends Error {
       if (isThinking()) return;
       const currentText = getLatestResponseText();
       if (!currentText || currentText === lastResponseText) return;
+      clearFinishResponseTimeout();
       lastResponseText = currentText;
 
       const now = Date.now();
@@ -629,7 +887,11 @@ class InputInjectionError extends Error {
         if (adapter) bridge.emit({ v: 1, action: 'RESPONSE_CHUNK', provider: adapter.provider, payload: currentText });
       }
       if (responseTimeout !== undefined) window.clearTimeout(responseTimeout);
-      responseTimeout = window.setTimeout(checkIfDone, timing('doneDelayMs', 3000));
+      const expectedGeneration = activeResponseGeneration;
+      responseTimeout = window.setTimeout(
+        () => checkIfDone(expectedGeneration),
+        timing('doneDelayMs', 3000),
+      );
     });
     observer.observe(document.body, { childList: true, subtree: true, characterData: true });
     observerInstalled = true;
@@ -645,10 +907,15 @@ class InputInjectionError extends Error {
       }
       const currentText = getLatestResponseText();
       if (!currentText || currentText === lastResponseText) return;
+      clearFinishResponseTimeout();
       lastResponseText = currentText;
       if (adapter) bridge.emit({ v: 1, action: 'RESPONSE_CHUNK', provider: adapter.provider, payload: currentText });
       if (responseTimeout !== undefined) window.clearTimeout(responseTimeout);
-      responseTimeout = window.setTimeout(checkIfDone, timing('doneDelayMs', 3000));
+      const expectedGeneration = activeResponseGeneration;
+      responseTimeout = window.setTimeout(
+        () => checkIfDone(expectedGeneration),
+        timing('doneDelayMs', 3000),
+      );
     }, timing('backupPollMs', 3000));
   }
 
@@ -657,8 +924,14 @@ class InputInjectionError extends Error {
     checkDoneInterval = undefined;
   }
 
+  function clearFinishResponseTimeout() {
+    if (finishResponseTimeout !== undefined) window.clearTimeout(finishResponseTimeout);
+    finishResponseTimeout = undefined;
+  }
+
   function clearTimersForResponse() {
     if (responseTimeout !== undefined) window.clearTimeout(responseTimeout);
+    clearFinishResponseTimeout();
     if (pollInterval !== undefined) window.clearInterval(pollInterval);
     clearCheckDone();
     responseTimeout = undefined;

--- a/shared/challenge-signals.json
+++ b/shared/challenge-signals.json
@@ -1,0 +1,32 @@
+{
+  "markerSelector": "#challenge-running, #challenge-stage, #cf-challenge-running, form#challenge-form, .h-captcha, [data-hcaptcha-widget-id], iframe[src*=\"hcaptcha.com\"], iframe[src*=\"challenges.cloudflare.com\"]",
+  "titleSignals": [
+    "just a moment",
+    "attention required",
+    "security verification",
+    "performing security verification",
+    "請稍候",
+    "请稍候",
+    "安全驗證",
+    "安全性驗證",
+    "安全验证",
+    "セキュリティ検証",
+    "sicherheitsüberprüfung"
+  ],
+  "bodySignals": [
+    "verifying you are human",
+    "verify you are human",
+    "performing security verification",
+    "checking if the site connection is secure",
+    "complete the security check",
+    "驗證您是人類",
+    "验证您是人类",
+    "確認您是人類",
+    "正在驗證您是否為真人",
+    "正在執行安全驗證",
+    "正在执行安全验证",
+    "人間であることを確認しています",
+    "sicherheitsüberprüfung"
+  ],
+  "bodySampleChars": 2000
+}

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -29,6 +29,12 @@ struct BridgeState {
     last_seq: HashMap<(String, String), u64>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProviderTransportSnapshot {
+    active_boot: Option<String>,
+    last_seq: Vec<(String, u64)>,
+}
+
 static STATE: OnceLock<Mutex<BridgeState>> = OnceLock::new();
 
 fn state() -> &'static Mutex<BridgeState> {
@@ -43,19 +49,27 @@ pub(crate) fn ingest_title(
     let mut msg = decode_title_frame(title).ok().flatten()?;
     let boot_id = msg.boot_id.clone()?;
     let seq = msg.seq?;
+    msg.provider = Some(provider.to_string());
+    msg.transport = Some("title".into());
+    if !is_title_action_allowed(&msg) || !webviews::bridge_title_is_eligible(provider, &msg) {
+        return None;
+    }
+
     let mut guard = state().lock().ok()?;
+    let previous = provider_transport_snapshot(&guard, provider);
     rotate_boot_if_needed(&mut guard, provider, &boot_id);
     if !accept_seq(&mut guard, provider, &boot_id, seq) {
         return None;
     }
     drop(guard);
 
-    msg.provider = Some(provider.to_string());
-    msg.transport = Some("title".into());
-    let _ = webviews::handle_bridge_title(app, provider, &msg);
-    if is_title_action_allowed(&msg) {
-        let _ = app.emit_to("main", "bridge://msg", &msg);
+    if !webviews::handle_bridge_title(app, provider, &msg).unwrap_or(false) {
+        if let Ok(mut guard) = state().lock() {
+            restore_rejected_transport(&mut guard, provider, &boot_id, seq, previous);
+        }
+        return None;
     }
+    let _ = app.emit_to("main", "bridge://msg", &msg);
     Some(msg)
 }
 
@@ -93,6 +107,43 @@ fn rotate_boot_if_needed(state: &mut BridgeState, provider: &str, boot_id: &str)
     state
         .active_boot
         .insert(provider.to_string(), boot_id.to_string());
+}
+
+fn provider_transport_snapshot(state: &BridgeState, provider: &str) -> ProviderTransportSnapshot {
+    ProviderTransportSnapshot {
+        active_boot: state.active_boot.get(provider).cloned(),
+        last_seq: state
+            .last_seq
+            .iter()
+            .filter(|((seq_provider, _), _)| seq_provider == provider)
+            .map(|((_, boot_id), seq)| (boot_id.clone(), *seq))
+            .collect(),
+    }
+}
+
+fn restore_rejected_transport(
+    state: &mut BridgeState,
+    provider: &str,
+    rejected_boot: &str,
+    rejected_seq: u64,
+    previous: ProviderTransportSnapshot,
+) {
+    let rejected_key = (provider.to_string(), rejected_boot.to_string());
+    if state.active_boot.get(provider).map(String::as_str) != Some(rejected_boot)
+        || state.last_seq.get(&rejected_key).copied() != Some(rejected_seq)
+    {
+        return;
+    }
+    state.active_boot.remove(provider);
+    if let Some(active_boot) = previous.active_boot {
+        state.active_boot.insert(provider.to_string(), active_boot);
+    }
+    state
+        .last_seq
+        .retain(|(seq_provider, _), _| seq_provider != provider);
+    for (boot_id, seq) in previous.last_seq {
+        state.last_seq.insert((provider.to_string(), boot_id), seq);
+    }
 }
 
 fn decode_title_frame(title: &str) -> Result<Option<BridgeMessage>, String> {
@@ -235,5 +286,31 @@ mod tests {
             state.active_boot.get("chatgpt").map(String::as_str),
             Some("new")
         );
+    }
+
+    #[test]
+    fn rejected_title_restores_the_previous_transport_boot() {
+        let mut state = BridgeState::default();
+        state.active_boot.insert("grok".into(), "current".into());
+        state.last_seq.insert(("grok".into(), "current".into()), 7);
+        let previous = provider_transport_snapshot(&state, "grok");
+
+        rotate_boot_if_needed(&mut state, "grok", "stale");
+        assert!(accept_seq(&mut state, "grok", "stale", 1));
+        restore_rejected_transport(&mut state, "grok", "stale", 1, previous);
+
+        assert_eq!(
+            state.active_boot.get("grok").map(String::as_str),
+            Some("current")
+        );
+        assert_eq!(
+            state
+                .last_seq
+                .get(&("grok".to_string(), "current".to_string())),
+            Some(&7)
+        );
+        assert!(!state
+            .last_seq
+            .contains_key(&("grok".to_string(), "stale".to_string())));
     }
 }

--- a/src-tauri/src/webviews.rs
+++ b/src-tauri/src/webviews.rs
@@ -10,7 +10,7 @@ use std::{
 };
 use tauri::{
     utils::config::BackgroundThrottlingPolicy,
-    webview::{NewWindowResponse, WebviewBuilder},
+    webview::{NewWindowResponse, PageLoadEvent, WebviewBuilder},
     AppHandle, Emitter, Manager, PhysicalPosition, PhysicalSize, WebviewUrl,
 };
 use tauri_plugin_opener::OpenerExt;
@@ -25,17 +25,27 @@ const ENGINE_JS: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/gen/injected/engine.js"
 ));
+const CHALLENGE_SIGNALS_JSON: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../shared/challenge-signals.json"
+));
 const PROVIDER_BROWSER_ARGS: &str = "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --disable-renderer-backgrounding --disable-backgrounding-occluded-windows";
 const NEW_SESSION_READY_TIMEOUT_SECS: u64 = 30;
 const NEW_SESSION_READY_POLL_MS: u64 = 150;
-// Bootstrap deliberately stays dormant on provider security checks. Turnstile can be embedded in
-// a page whose top-level title remains "Grok", so the native title observer alone cannot surface
-// every blocked login. This host probe only reads known markers and never creates the bridge.
-const GROK_CHALLENGE_PROBE_JS: &str = r#"Boolean(
-  window.self === window.top &&
-  !window.__MAC_BRIDGE__ &&
-  document.querySelector('#challenge-running, #challenge-stage, #cf-challenge-running, form#challenge-form, .h-captcha, [data-hcaptcha-widget-id], iframe[src*="hcaptcha.com"], iframe[src*="challenges.cloudflare.com"]')
-)"#;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ChallengeSignals {
+    title_signals: Vec<String>,
+}
+
+fn challenge_signals() -> &'static ChallengeSignals {
+    static SIGNALS: OnceLock<ChallengeSignals> = OnceLock::new();
+    SIGNALS.get_or_init(|| {
+        serde_json::from_str(CHALLENGE_SIGNALS_JSON)
+            .expect("shared/challenge-signals.json must be valid")
+    })
+}
 /// Auto-deny site permission prompts that otherwise pop a blocking native dialog.
 /// SCOPE: Notifications + Geolocation ONLY. We intentionally leave microphone/camera alone so the
 /// providers' voice-input buttons keep working. Runs at document-start, before site scripts.
@@ -69,10 +79,6 @@ fn provider_uses_permission_shim(provider: &str) -> bool {
     provider != "grok"
 }
 
-fn provider_uses_automation_browser_tuning(provider: &str) -> bool {
-    provider != "grok"
-}
-
 fn provider_uses_document_start_bridge(provider: &str) -> bool {
     provider != "grok"
 }
@@ -95,30 +101,14 @@ fn grok_challenge_title_active(provider: &str, title: &str) -> bool {
         return false;
     }
     let normalized = title.trim().to_lowercase();
-    [
-        "just a moment",
-        "attention required",
-        "security verification",
-        "performing security verification",
-        "請稍候",
-        "请稍候",
-        "安全驗證",
-        "安全性驗證",
-        "安全验证",
-        "セキュリティ検証",
-        "sicherheitsüberprüfung",
-    ]
-    .iter()
-    .any(|signal| normalized.contains(signal))
+    challenge_signals()
+        .title_signals
+        .iter()
+        .any(|signal| normalized.contains(signal))
 }
 
 fn handle_provider_document_title(app: &AppHandle, provider: &str, title: &str) {
-    if crate::bridge::ingest_title(app, provider, title).is_some()
-        || !grok_challenge_title_active(provider, title)
-    {
-        return;
-    }
-    set_provider_challenge_blocked(app, provider);
+    let _ = crate::bridge::ingest_title(app, provider, title);
 }
 
 fn set_provider_challenge_blocked(app: &AppHandle, provider: &str) {
@@ -182,10 +172,21 @@ struct ProviderRuntime {
     engine_boot: HashMap<String, String>,
     bridge_boot: HashMap<String, String>,
     status_boot: HashMap<String, String>,
+    grok_document_epoch: HashMap<String, u64>,
+    grok_adopted_boot: HashMap<String, (u64, String)>,
+    grok_pending_navigation: HashMap<String, GrokNavigationPreparation>,
     pending_session_boot: HashMap<String, Option<String>>,
     last_push_ms: HashMap<String, u64>,
     stale_check_sent: HashMap<String, u64>,
     watchdog_started: bool,
+}
+
+#[derive(Debug, Clone)]
+struct GrokNavigationPreparation {
+    epoch: u64,
+    previous_epoch: u64,
+    previous_adopted_boot: Option<(u64, String)>,
+    previous_status_boot: Option<String>,
 }
 
 static RUNTIME: OnceLock<Mutex<ProviderRuntime>> = OnceLock::new();
@@ -194,26 +195,306 @@ fn runtime() -> &'static Mutex<ProviderRuntime> {
     RUNTIME.get_or_init(|| Mutex::new(ProviderRuntime::default()))
 }
 
-fn should_probe_grok_challenge(state: &ProviderState) -> bool {
-    state.provider == "grok" && state.webview == "loaded" && state.login != "blocked"
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GrokBridgeDriveOutcome {
+    Challenge,
+    Installed,
+    Present,
+    Waiting,
+    Retry,
+    Ineligible,
 }
 
-fn grok_challenge_probe_is_current(
-    observed_state: &ProviderState,
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GrokBridgeDriveResult {
+    outcome: GrokBridgeDriveOutcome,
+    boot_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GrokBridgeHostAction {
+    Ignore,
+    MarkBlocked,
+}
+
+fn prepare_grok_navigation(provider: &str) -> u64 {
+    if provider != "grok" {
+        return 0;
+    }
+    let Ok(mut guard) = runtime().lock() else {
+        return 0;
+    };
+    if let Some(pending) = guard.grok_pending_navigation.get(provider) {
+        return pending.epoch;
+    }
+    let previous_epoch = guard
+        .grok_document_epoch
+        .get(provider)
+        .copied()
+        .unwrap_or_default();
+    let previous_adopted_boot = guard.grok_adopted_boot.remove(provider);
+    let previous_status_boot = guard.status_boot.get(provider).cloned();
+    let next_epoch = previous_epoch.saturating_add(1);
+    guard.grok_pending_navigation.insert(
+        provider.to_string(),
+        GrokNavigationPreparation {
+            epoch: next_epoch,
+            previous_epoch,
+            previous_adopted_boot,
+            previous_status_boot,
+        },
+    );
+    next_epoch
+}
+
+fn confirm_grok_page_load(provider: &str) -> u64 {
+    if provider != "grok" {
+        return 0;
+    }
+    let Ok(mut guard) = runtime().lock() else {
+        return 0;
+    };
+    if let Some(pending) = guard.grok_pending_navigation.remove(provider) {
+        guard
+            .grok_document_epoch
+            .insert(provider.to_string(), pending.epoch);
+        guard.grok_adopted_boot.remove(provider);
+        return pending.epoch;
+    }
+    guard.grok_adopted_boot.remove(provider);
+    let epoch = guard
+        .grok_document_epoch
+        .entry(provider.to_string())
+        .or_default();
+    *epoch = epoch.saturating_add(1);
+    *epoch
+}
+
+fn cancel_grok_navigation(provider: &str, prepared_epoch: u64) {
+    if provider != "grok" || prepared_epoch == 0 {
+        return;
+    }
+    let Ok(mut guard) = runtime().lock() else {
+        return;
+    };
+    let Some(pending) = guard.grok_pending_navigation.get(provider).cloned() else {
+        return;
+    };
+    if pending.epoch != prepared_epoch {
+        return;
+    }
+    if guard
+        .grok_document_epoch
+        .get(provider)
+        .copied()
+        .unwrap_or_default()
+        != pending.previous_epoch
+    {
+        return;
+    }
+    guard.grok_pending_navigation.remove(provider);
+    match pending.previous_adopted_boot {
+        Some(previous) => {
+            guard
+                .grok_adopted_boot
+                .insert(provider.to_string(), previous);
+        }
+        None => {
+            guard.grok_adopted_boot.remove(provider);
+        }
+    }
+    match pending.previous_status_boot {
+        Some(previous) => {
+            guard.status_boot.insert(provider.to_string(), previous);
+        }
+        None => {
+            guard.status_boot.remove(provider);
+        }
+    }
+}
+
+fn retire_grok_document(provider: &str) {
+    if provider != "grok" {
+        return;
+    }
+    let Ok(mut guard) = runtime().lock() else {
+        return;
+    };
+    guard.grok_pending_navigation.remove(provider);
+    guard.grok_adopted_boot.remove(provider);
+    let epoch = guard
+        .grok_document_epoch
+        .entry(provider.to_string())
+        .or_default();
+    *epoch = epoch.saturating_add(1);
+}
+
+fn adopt_grok_bridge_boot(provider: &str, observed_epoch: u64, boot_id: &str) -> bool {
+    if provider != "grok" || observed_epoch == 0 || boot_id.is_empty() {
+        return false;
+    }
+    let Ok(mut guard) = runtime().lock() else {
+        return false;
+    };
+    if guard.grok_document_epoch.get(provider).copied() != Some(observed_epoch) {
+        return false;
+    }
+    if guard.grok_pending_navigation.contains_key(provider) {
+        return false;
+    }
+    guard
+        .grok_adopted_boot
+        .insert(provider.to_string(), (observed_epoch, boot_id.to_string()));
+    true
+}
+
+fn grok_bridge_result_is_current(provider: &str, observed_epoch: u64) -> bool {
+    provider == "grok"
+        && observed_epoch != 0
+        && runtime().lock().ok().is_some_and(|guard| {
+            guard.grok_document_epoch.get(provider).copied() == Some(observed_epoch)
+                && !guard.grok_pending_navigation.contains_key(provider)
+        })
+}
+
+fn grok_bridge_boot_is_current(provider: &str, boot_id: Option<&str>) -> bool {
+    if provider != "grok" {
+        return true;
+    }
+    let Some(boot_id) = boot_id else {
+        return false;
+    };
+    runtime().lock().ok().is_some_and(|guard| {
+        let current_epoch = guard
+            .grok_document_epoch
+            .get(provider)
+            .copied()
+            .unwrap_or_default();
+        guard
+            .grok_adopted_boot
+            .get(provider)
+            .is_some_and(|(epoch, adopted_boot)| *epoch == current_epoch && adopted_boot == boot_id)
+    })
+}
+
+fn current_grok_document_epoch(provider: &str) -> u64 {
+    runtime()
+        .lock()
+        .ok()
+        .and_then(|guard| guard.grok_document_epoch.get(provider).copied())
+        .unwrap_or_default()
+}
+
+fn should_drive_grok_bridge(state: &ProviderState) -> bool {
+    state.provider == "grok" && state.webview == "loaded" && state.dom != "ready"
+}
+
+fn grok_bridge_drive_allowed(state: &ProviderState) -> bool {
+    state.provider == "grok"
+        && matches!(state.webview.as_str(), "creating" | "loaded")
+        && state.dom != "ready"
+}
+
+fn grok_bridge_host_action(
+    outcome: GrokBridgeDriveOutcome,
+    observed_epoch: u64,
+    current_epoch: u64,
     current_state: &ProviderState,
-) -> bool {
-    should_probe_grok_challenge(current_state) && current_state == observed_state
+) -> GrokBridgeHostAction {
+    if observed_epoch == 0
+        || observed_epoch != current_epoch
+        || !grok_bridge_drive_allowed(current_state)
+    {
+        return GrokBridgeHostAction::Ignore;
+    }
+    match outcome {
+        GrokBridgeDriveOutcome::Challenge => GrokBridgeHostAction::MarkBlocked,
+        GrokBridgeDriveOutcome::Installed
+        | GrokBridgeDriveOutcome::Present
+        | GrokBridgeDriveOutcome::Waiting
+        | GrokBridgeDriveOutcome::Retry
+        | GrokBridgeDriveOutcome::Ineligible => GrokBridgeHostAction::Ignore,
+    }
 }
 
-fn set_grok_challenge_blocked_if_unchanged(app: &AppHandle, observed_state: &ProviderState) {
+fn parse_grok_bridge_drive_outcome(raw: &str) -> Option<GrokBridgeDriveResult> {
+    let mut value = serde_json::from_str::<serde_json::Value>(raw).ok()?;
+    let value = match value {
+        serde_json::Value::String(nested) => {
+            value = serde_json::from_str::<serde_json::Value>(&nested)
+                .unwrap_or(serde_json::Value::String(nested));
+            value
+        }
+        value => value,
+    };
+    let (outcome, boot_id) = match value {
+        serde_json::Value::String(outcome) => (outcome, None),
+        serde_json::Value::Object(mut result) => (
+            result.remove("outcome")?.as_str()?.to_string(),
+            result
+                .remove("bootId")
+                .and_then(|value| value.as_str().map(str::to_string)),
+        ),
+        _ => return None,
+    };
+    let outcome = match outcome.as_str() {
+        "challenge" => GrokBridgeDriveOutcome::Challenge,
+        "installed" => GrokBridgeDriveOutcome::Installed,
+        "present" => GrokBridgeDriveOutcome::Present,
+        "waiting" => GrokBridgeDriveOutcome::Waiting,
+        "retry" => GrokBridgeDriveOutcome::Retry,
+        "ineligible" => GrokBridgeDriveOutcome::Ineligible,
+        _ => return None,
+    };
+    Some(GrokBridgeDriveResult { outcome, boot_id })
+}
+
+fn apply_grok_bridge_drive_outcome(
+    app: &AppHandle,
+    provider: &str,
+    observed_epoch: u64,
+    result: GrokBridgeDriveResult,
+) {
+    if !grok_bridge_result_is_current(provider, observed_epoch) {
+        return;
+    }
+    if matches!(
+        result.outcome,
+        GrokBridgeDriveOutcome::Installed | GrokBridgeDriveOutcome::Present
+    ) {
+        let Some(boot_id) = result.boot_id.as_deref() else {
+            return;
+        };
+        if !adopt_grok_bridge_boot(provider, observed_epoch, boot_id) {
+            return;
+        }
+        let check = serde_json::json!({
+            "v": 1,
+            "action": "CHECK_STATUS",
+            "provider": provider
+        });
+        let script = format!(
+            "window.__MAC_BRIDGE__ && window.__MAC_BRIDGE__.dispatch({});",
+            serde_json::to_string(&check).unwrap_or_default()
+        );
+        let _ = eval_provider(app, provider, &script);
+        return;
+    }
     let next_state = {
         let Ok(mut guard) = runtime().lock() else {
             return;
         };
-        let Some(current_state) = guard.states.get(&observed_state.provider) else {
+        let current_epoch = guard
+            .grok_document_epoch
+            .get(provider)
+            .copied()
+            .unwrap_or_default();
+        let Some(current_state) = guard.states.get(provider) else {
             return;
         };
-        if !grok_challenge_probe_is_current(observed_state, current_state) {
+        if grok_bridge_host_action(result.outcome, observed_epoch, current_epoch, current_state)
+            != GrokBridgeHostAction::MarkBlocked
+        {
             return;
         }
         let mut next_state = current_state.clone();
@@ -224,21 +505,27 @@ fn set_grok_challenge_blocked_if_unchanged(app: &AppHandle, observed_state: &Pro
         next_state.last_status_at = now_ms();
         guard
             .states
-            .insert(next_state.provider.clone(), next_state.clone());
+            .insert(provider.to_string(), next_state.clone());
         next_state
     };
     let _ = app.emit_to("main", "connections://update", &next_state);
 }
 
-fn probe_grok_challenge(app: &AppHandle, observed_state: ProviderState) {
-    let label = provider_label(&observed_state.provider);
-    let Some(webview) = app.get_webview(&label) else {
+fn drive_grok_bridge_on_webview(
+    webview: &tauri::Webview,
+    app: &AppHandle,
+    provider: &str,
+    script: &str,
+    observed_epoch: u64,
+) {
+    if !grok_bridge_result_is_current(provider, observed_epoch) {
         return;
-    };
+    }
     let app = app.clone();
-    let _ = webview.eval_with_callback(GROK_CHALLENGE_PROBE_JS, move |raw| {
-        if eval_callback_reports_true(&raw) {
-            set_grok_challenge_blocked_if_unchanged(&app, &observed_state);
+    let provider = provider.to_string();
+    let _ = webview.eval_with_callback(script, move |raw| {
+        if let Some(result) = parse_grok_bridge_drive_outcome(&raw) {
+            apply_grok_bridge_drive_outcome(&app, &provider, observed_epoch, result);
         }
     });
 }
@@ -359,7 +646,10 @@ pub async fn provider_open(
     // the old Windows-only `register_title_watcher` (whose non-Windows branch was a no-op stub).
     let title_app = app.clone();
     let title_provider = provider.clone();
-    let title_delayed_grok_script = delayed_grok_script;
+    let title_delayed_grok_script = delayed_grok_script.clone();
+    let load_app = app.clone();
+    let load_provider = provider.clone();
+    let load_delayed_grok_script = delayed_grok_script;
     let builder = WebviewBuilder::new(&label, WebviewUrl::External(url));
     // Grok's Cloudflare challenge must see a stock document from its first instruction.
     // Install the automation bridge only after the real app page is confirmed below.
@@ -376,41 +666,72 @@ pub async fn provider_open(
     } else {
         builder
     };
-    let builder = builder.data_directory(profile_dir);
-    // Keep Grok's challenge environment close to stock WebView2. Other providers retain
-    // background execution tuning for hidden workflow automation.
-    let builder = if provider_uses_automation_browser_tuning(&provider) {
-        builder
-            .background_throttling(BackgroundThrottlingPolicy::Disabled)
-            .additional_browser_args(PROVIDER_BROWSER_ARGS)
-    } else {
-        builder
-    };
+    // Every provider is parked offscreen outside its active pane. Preserve the shipped liveness
+    // tuning so provider timers and renderers keep running while hidden.
     let builder = builder
+        .data_directory(profile_dir)
+        .background_throttling(BackgroundThrottlingPolicy::Disabled)
+        .additional_browser_args(PROVIDER_BROWSER_ARGS)
         .on_document_title_changed(move |webview, title| {
+            let document_epoch = current_grok_document_epoch(&title_provider);
             handle_provider_document_title(&title_app, &title_provider, &title);
             let install_ready = webview
                 .url()
                 .ok()
                 .is_some_and(|url| grok_bridge_install_ready(&title_provider, &title, &url));
+            let challenge_ready = grok_challenge_title_active(&title_provider, &title)
+                && webview.url().ok().is_some_and(|url| {
+                    adapters::url_matches_provider_app(&title_provider, &url).unwrap_or(false)
+                });
             let Some(script) = title_delayed_grok_script.as_deref() else {
                 return;
             };
-            if !install_ready {
+            if !install_ready && !challenge_ready {
+                return;
+            }
+            if !grok_bridge_drive_allowed(&current_state(&title_provider)) {
                 return;
             }
 
-            // A Turnstile iframe can leave the top-level title as "Grok". Require the
-            // read-only challenge probe to return an explicit false before installing.
-            // Use this event's WebView directly: title events may arrive before the
-            // child is discoverable through AppHandle's webview registry.
-            let install_webview = webview.clone();
-            let script = script.to_string();
-            let _ = webview.eval_with_callback(GROK_CHALLENGE_PROBE_JS, move |raw| {
-                if eval_callback_reports_false(&raw) {
-                    let _ = install_webview.eval(&script);
+            // Use this event's WebView directly: title events may arrive before the child is
+            // discoverable through AppHandle's webview registry. The driver probes and installs
+            // atomically in one JavaScript task.
+            drive_grok_bridge_on_webview(
+                &webview,
+                &title_app,
+                &title_provider,
+                script,
+                document_epoch,
+            );
+        })
+        .on_page_load(move |webview, payload| {
+            if load_provider != "grok" {
+                return;
+            }
+            match payload.event() {
+                PageLoadEvent::Started => {
+                    confirm_grok_page_load(&load_provider);
+                    reset_bridge_state(&load_app, &load_provider);
                 }
-            });
+                PageLoadEvent::Finished => {
+                    let Some(script) = load_delayed_grok_script.as_deref() else {
+                        return;
+                    };
+                    if !adapters::url_matches_provider_app(&load_provider, payload.url())
+                        .unwrap_or(false)
+                        || !grok_bridge_drive_allowed(&current_state(&load_provider))
+                    {
+                        return;
+                    }
+                    drive_grok_bridge_on_webview(
+                        &webview,
+                        &load_app,
+                        &load_provider,
+                        script,
+                        current_grok_document_epoch(&load_provider),
+                    );
+                }
+            }
         })
         .on_navigation(move |url| {
             if url.host_str() == Some("mac-bridge.invalid") {
@@ -484,12 +805,23 @@ pub async fn provider_open(
             }
         });
 
-    let webview = window
-        .add_child(builder, position, size)
-        .map_err(|error| error.to_string())?;
+    let prepared_epoch = prepare_grok_navigation(&provider);
+    let webview = match window.add_child(builder, position, size) {
+        Ok(webview) => webview,
+        Err(error) => {
+            cancel_grok_navigation(&provider, prepared_epoch);
+            return Err(error.to_string());
+        }
+    };
     webview.show().map_err(|error| error.to_string())?;
-    let state = state_with(&provider, "loaded", "unknown", "unknown", false);
-    set_state(&app, state.clone());
+    let current = current_state(&provider);
+    let state = if current.webview == "loaded" {
+        current
+    } else {
+        let state = state_with(&provider, "loaded", "unknown", "unknown", false);
+        set_state(&app, state.clone());
+        state
+    };
     Ok(state)
 }
 
@@ -501,6 +833,7 @@ pub async fn provider_close(
 ) -> Result<(), String> {
     ensure_control_webview(&webview)?;
     let label = provider_label(&provider);
+    retire_grok_document(&provider);
     if let Some(webview) = app.get_webview(&label) {
         webview.close().map_err(|error| error.to_string())?;
     }
@@ -508,6 +841,8 @@ pub async fn provider_close(
         guard.engine_boot.remove(&provider);
         guard.bridge_boot.remove(&provider);
         guard.status_boot.remove(&provider);
+        guard.grok_adopted_boot.remove(&provider);
+        guard.grok_pending_navigation.remove(&provider);
         guard.pending_session_boot.remove(&provider);
         guard.last_push_ms.remove(&provider);
     }
@@ -661,8 +996,13 @@ pub async fn provider_reload(
     provider: String,
 ) -> Result<(), String> {
     ensure_control_webview(&webview)?;
+    let prepared_epoch = prepare_grok_navigation(&provider);
     reset_bridge_state(&app, &provider);
-    eval_provider(&app, &provider, "location.reload();")
+    if let Err(error) = eval_provider(&app, &provider, "location.reload();") {
+        cancel_grok_navigation(&provider, prepared_epoch);
+        return Err(error);
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -676,13 +1016,18 @@ pub async fn provider_new_session(
         return Err(format!("provider webview is not open: {provider}"));
     }
     let adapter = adapters::get_adapter(&provider)?;
-    begin_session_reset(&app, &provider)?;
+    let prepared_epoch = prepare_grok_navigation(&provider);
+    if let Err(error) = begin_session_reset(&app, &provider) {
+        cancel_grok_navigation(&provider, prepared_epoch);
+        return Err(error);
+    }
     let js = format!(
         "location.href = {};",
         serde_json::to_string(&adapter.urls.app).map_err(|error| error.to_string())?
     );
     if let Err(error) = eval_provider(&app, &provider, &js) {
         cancel_session_reset(&provider);
+        cancel_grok_navigation(&provider, prepared_epoch);
         return Err(error);
     }
 
@@ -710,6 +1055,7 @@ pub async fn provider_new_session(
     }
 
     cancel_session_reset(&provider);
+    cancel_grok_navigation(&provider, prepared_epoch);
     Err(format!(
         "provider new session did not become ready within {} seconds: {provider}",
         NEW_SESSION_READY_TIMEOUT_SECS
@@ -757,16 +1103,20 @@ pub async fn dev_log(
     Ok(())
 }
 
+pub(crate) fn bridge_title_is_eligible(provider: &str, msg: &BridgeMessage) -> bool {
+    msg.action != "STATUS_REPORT" || grok_bridge_boot_is_current(provider, msg.boot_id.as_deref())
+}
+
 pub(crate) fn handle_bridge_title(
     app: &AppHandle,
     provider: &str,
     msg: &BridgeMessage,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     if msg.action != "STATUS_REPORT" {
-        return Ok(());
+        return Ok(true);
     }
     if !accept_status_for_session_reset(provider, msg.boot_id.as_deref()) {
-        return Ok(());
+        return Ok(false);
     }
     if should_reset_bridge_on_boot_rotation(provider, msg.boot_id.as_deref()) {
         let mut state = current_state(provider);
@@ -800,7 +1150,7 @@ pub(crate) fn handle_bridge_title(
         }
     }
     update_status_state(app, provider, payload, msg.boot_id.as_deref());
-    Ok(())
+    Ok(true)
 }
 
 fn should_reset_bridge_on_boot_rotation(provider: &str, incoming_boot: Option<&str>) -> bool {
@@ -847,6 +1197,10 @@ pub(crate) fn push_engine_and_adapter(app: &AppHandle, provider: &str) -> Result
 
 fn delayed_grok_bridge_script(provider: &str) -> Result<String, String> {
     let adapter = adapters::get_adapter(provider)?;
+    let challenge_signals = serde_json::from_str::<serde_json::Value>(CHALLENGE_SIGNALS_JSON)
+        .map_err(|error| format!("invalid shared challenge signals: {error}"))?;
+    let challenge_signals_json =
+        serde_json::to_string(&challenge_signals).map_err(|error| error.to_string())?;
     let provider_json = serde_json::to_string(provider).map_err(|error| error.to_string())?;
     let dispatch_adapter = serde_json::json!({
         "v": 1,
@@ -859,34 +1213,100 @@ fn delayed_grok_bridge_script(provider: &str) -> Result<String, String> {
         "action": "CHECK_STATUS",
         "provider": provider
     });
-    Ok(format!(
-        r#"if (
-  window.self === window.top &&
-  location.protocol === 'https:' &&
-  location.hostname === 'grok.com' &&
-  !document.querySelector('#challenge-running, #challenge-stage, #cf-challenge-running, form#challenge-form, .h-captcha, [data-hcaptcha-widget-id], iframe[src*="hcaptcha.com"], iframe[src*="challenges.cloudflare.com"]') &&
-  !window.__MAC_GROK_DELAYED_INSTALL__
-) {{
-  window.__MAC_GROK_DELAYED_INSTALL__ = true;
-  window.__MAC_PROVIDER__ = {provider_json};
-  {bootstrap}
-  (function installGrokEngine(attempt) {{
-    if (window.__MAC_BRIDGE__) {{
-      {engine}
-      window.__MAC_BRIDGE__.dispatch({adapter_msg});
-      window.__MAC_BRIDGE__.dispatch({check_msg});
-      return;
-    }}
-    if (attempt < 120) {{
-      window.setTimeout(function () {{ installGrokEngine(attempt + 1); }}, 250);
-    }}
-  }})(0);
-}}"#,
-        bootstrap = BOOTSTRAP_JS,
-        engine = ENGINE_JS,
-        adapter_msg = serde_json::to_string(&dispatch_adapter).map_err(|error| error.to_string())?,
-        check_msg = serde_json::to_string(&dispatch_check).map_err(|error| error.to_string())?,
-    ))
+    let template = r#"(function driveGrokBridge() {
+  try {
+    if (
+      window.self !== window.top ||
+      location.protocol !== 'https:' ||
+      location.hostname !== 'grok.com'
+    ) {
+      return { outcome: 'ineligible' };
+    }
+
+    var challengeSignals = __MAC_CHALLENGE_SIGNALS_JSON__;
+    function normalize(value) {
+      return String(value || '').trim().toLocaleLowerCase();
+    }
+    function includesSignal(value, signals) {
+      var normalized = normalize(value);
+      return signals.some(function (signal) { return normalized.indexOf(signal) !== -1; });
+    }
+    function sampleBodyText() {
+      if (!document.body) return '';
+      try {
+        var walker = document.createTreeWalker(document.body, 4);
+        var sample = '';
+        var node = walker.nextNode();
+        while (node && sample.length < challengeSignals.bodySampleChars) {
+          if (node.nodeValue) {
+            sample += ' ' + node.nodeValue.slice(0, challengeSignals.bodySampleChars - sample.length);
+          }
+          node = walker.nextNode();
+        }
+        return sample.slice(0, challengeSignals.bodySampleChars);
+      } catch (_) {
+        return String(document.body.innerText || document.body.textContent || '')
+          .slice(0, challengeSignals.bodySampleChars);
+      }
+    }
+    function challengeActive() {
+      if (document.querySelector(challengeSignals.markerSelector)) return true;
+      if (includesSignal(document.title, challengeSignals.titleSignals)) return true;
+      return includesSignal(sampleBodyText(), challengeSignals.bodySignals);
+    }
+    function installEngineAndAdapter() {
+      __MAC_ENGINE_JS__
+      window.__MAC_BRIDGE__.dispatch(__MAC_ADAPTER_MESSAGE__);
+      window.__MAC_BRIDGE__.dispatch(__MAC_CHECK_MESSAGE__);
+    }
+
+    // This read-only decision and the bridge installation run in one JavaScript task. No provider
+    // global or DOM state is changed unless the challenge result is explicitly negative.
+    if (challengeActive()) return { outcome: 'challenge' };
+    if (window.__MAC_BRIDGE__) {
+      installEngineAndAdapter();
+      return { outcome: 'present', bootId: String(window.__MAC_BRIDGE__.bootId || '') };
+    }
+    if (document.readyState === 'loading') return { outcome: 'waiting' };
+
+    var title = normalize(document.title);
+    if (!(title === 'grok' || title.indexOf('grok - ') === 0 || title.indexOf('grok — ') === 0)) {
+      return { outcome: 'ineligible' };
+    }
+
+    window.__MAC_PROVIDER__ = __MAC_PROVIDER_JSON__;
+    __MAC_BOOTSTRAP_JS__
+    if (!window.__MAC_BRIDGE__) {
+      return { outcome: challengeActive() ? 'challenge' : 'waiting' };
+    }
+    installEngineAndAdapter();
+    return { outcome: 'installed', bootId: String(window.__MAC_BRIDGE__.bootId || '') };
+  } catch (error) {
+    try { console.error('[MAC Grok bridge driver]', error); } catch (_) {}
+    return { outcome: 'retry' };
+  }
+})()"#;
+    Ok(template
+        .replace("__MAC_CHALLENGE_SIGNALS_JSON__", &challenge_signals_json)
+        .replace("__MAC_ENGINE_JS__", ENGINE_JS)
+        .replace(
+            "__MAC_ADAPTER_MESSAGE__",
+            &serde_json::to_string(&dispatch_adapter).map_err(|error| error.to_string())?,
+        )
+        .replace(
+            "__MAC_CHECK_MESSAGE__",
+            &serde_json::to_string(&dispatch_check).map_err(|error| error.to_string())?,
+        )
+        .replace("__MAC_PROVIDER_JSON__", &provider_json)
+        .replace("__MAC_BOOTSTRAP_JS__", BOOTSTRAP_JS))
+}
+
+fn cached_grok_bridge_script() -> Result<&'static str, String> {
+    static SCRIPT: OnceLock<Result<String, String>> = OnceLock::new();
+    match SCRIPT.get_or_init(|| delayed_grok_bridge_script("grok")) {
+        Ok(script) => Ok(script.as_str()),
+        Err(error) => Err(error.clone()),
+    }
 }
 
 fn update_status_state(
@@ -1072,6 +1492,25 @@ fn accept_status_for_session_reset(provider: &str, incoming_boot: Option<&str>) 
     let Ok(mut guard) = runtime().lock() else {
         return false;
     };
+    if provider == "grok" {
+        let Some(incoming_boot) = incoming_boot else {
+            return false;
+        };
+        let current_epoch = guard
+            .grok_document_epoch
+            .get(provider)
+            .copied()
+            .unwrap_or_default();
+        if !guard
+            .grok_adopted_boot
+            .get(provider)
+            .is_some_and(|(epoch, adopted_boot)| {
+                *epoch == current_epoch && adopted_boot == incoming_boot
+            })
+        {
+            return false;
+        }
+    }
     if let Some(previous_boot) = guard.pending_session_boot.get(provider).cloned() {
         if !fresh_session_boot(previous_boot.as_deref(), incoming_boot) {
             return false;
@@ -1092,10 +1531,6 @@ fn fresh_session_boot(previous_boot: Option<&str>, incoming_boot: Option<&str>) 
 
 fn eval_callback_reports_true(raw: &str) -> bool {
     eval_callback_boolean(raw) == Some(true)
-}
-
-fn eval_callback_reports_false(raw: &str) -> bool {
-    eval_callback_boolean(raw) == Some(false)
 }
 
 fn eval_callback_boolean(raw: &str) -> Option<bool> {
@@ -1149,12 +1584,17 @@ fn run_staleness_check(app: &AppHandle) {
     let now = now_ms();
     let mut to_check = Vec::new();
     let mut to_mark_unknown = Vec::new();
-    let mut to_probe = Vec::new();
+    let mut grok_to_drive = Vec::new();
     if let Ok(mut guard) = runtime().lock() {
         let providers = guard.states.values().cloned().collect::<Vec<_>>();
         for state in providers {
-            if should_probe_grok_challenge(&state) {
-                to_probe.push(state.clone());
+            if should_drive_grok_bridge(&state) {
+                let document_epoch = guard
+                    .grok_document_epoch
+                    .get(&state.provider)
+                    .copied()
+                    .unwrap_or_default();
+                grok_to_drive.push((state.provider.clone(), document_epoch));
             }
             match staleness_action(state.last_status_at, now, state.webview == "loaded") {
                 StalenessAction::None => {}
@@ -1172,8 +1612,12 @@ fn run_staleness_check(app: &AppHandle) {
             }
         }
     }
-    for state in to_probe {
-        probe_grok_challenge(app, state);
+    if let Ok(script) = cached_grok_bridge_script() {
+        for (provider, document_epoch) in grok_to_drive {
+            if let Some(webview) = app.get_webview(&provider_label(&provider)) {
+                drive_grok_bridge_on_webview(&webview, app, &provider, script, document_epoch);
+            }
+        }
     }
     for provider in to_check {
         let msg = serde_json::json!({ "v": 1, "action": "CHECK_STATUS", "provider": provider });
@@ -1220,21 +1664,26 @@ fn now_ms() -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use tauri::{PhysicalPosition, PhysicalSize};
 
     use super::{
-        accept_status_for_session_reset, bridge_resets_on_boot_rotation, cancel_session_reset,
-        challenge_auxiliary_navigation_allowed, decide_new_window_action,
-        delayed_grok_bridge_script, eval_callback_reports_false, eval_callback_reports_true,
-        fresh_session_boot, gemini_sorry_navigation_active, grok_app_title_ready,
-        grok_bridge_install_ready, grok_challenge_probe_is_current, grok_challenge_title_active,
-        physical_bounds, popup_initial_title, provider_show_should_focus,
-        provider_uses_automation_browser_tuning, provider_uses_document_start_bridge,
-        provider_uses_permission_shim, runtime, should_probe_grok_challenge,
+        accept_status_for_session_reset, adopt_grok_bridge_boot, bridge_resets_on_boot_rotation,
+        cancel_grok_navigation, cancel_session_reset, challenge_auxiliary_navigation_allowed,
+        confirm_grok_page_load, decide_new_window_action, delayed_grok_bridge_script,
+        eval_callback_reports_true, fresh_session_boot, gemini_sorry_navigation_active,
+        grok_app_title_ready, grok_bridge_drive_allowed, grok_bridge_host_action,
+        grok_bridge_install_ready, grok_bridge_result_is_current, grok_challenge_title_active,
+        parse_grok_bridge_drive_outcome, physical_bounds, popup_initial_title,
+        prepare_grok_navigation, provider_show_should_focus, provider_uses_document_start_bridge,
+        provider_uses_permission_shim, runtime, should_drive_grok_bridge,
         should_reset_bridge_on_boot_rotation, staleness_action, state_with, Bounds,
-        NewWindowAction, StalenessAction, GROK_CHALLENGE_PROBE_JS, PERMISSION_SHIM_JS,
-        PROVIDER_BROWSER_ARGS,
+        GrokBridgeDriveOutcome, GrokBridgeDriveResult, GrokBridgeHostAction, NewWindowAction,
+        StalenessAction, CHALLENGE_SIGNALS_JSON, PERMISSION_SHIM_JS, PROVIDER_BROWSER_ARGS,
     };
+
+    static GROK_RUNTIME_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     fn url(input: &str) -> tauri::Url {
         tauri::Url::parse(input).expect("test URL should parse")
@@ -1258,17 +1707,15 @@ mod tests {
     #[test]
     fn grok_keeps_core_web_apis_unmodified_for_cloudflare_challenges() {
         assert!(!provider_uses_permission_shim("grok"));
-        assert!(!provider_uses_automation_browser_tuning("grok"));
         assert!(!provider_uses_document_start_bridge("grok"));
         for provider in ["chatgpt", "claude", "gemini"] {
             assert!(provider_uses_permission_shim(provider));
-            assert!(provider_uses_automation_browser_tuning(provider));
             assert!(provider_uses_document_start_bridge(provider));
         }
     }
 
     #[test]
-    fn grok_bridge_waits_for_the_real_app_and_a_negative_challenge_probe() {
+    fn grok_bridge_waits_for_the_real_app_and_an_atomic_negative_challenge_check() {
         assert!(grok_app_title_ready("grok", "Grok"));
         assert!(grok_app_title_ready("grok", "Grok — Home"));
         assert!(!grok_app_title_ready("grok", "grok.com 正在執行安全驗證"));
@@ -1284,18 +1731,25 @@ mod tests {
             "Grok",
             &url("https://accounts.x.ai/sign-in")
         ));
-        assert!(!eval_callback_reports_false("null"));
-        assert!(!eval_callback_reports_false(r#""unexpected""#));
-        assert!(eval_callback_reports_false("false"));
-        assert!(eval_callback_reports_false(r#""false""#));
 
         let script = delayed_grok_bridge_script("grok").expect("delayed script should build");
-        assert!(script.contains("__MAC_GROK_DELAYED_INSTALL__"));
-        assert!(script.contains("location.hostname === 'grok.com'"));
+        assert!(!script.contains("__MAC_GROK_DELAYED_INSTALL__"));
+        assert!(script.contains("location.hostname !== 'grok.com'"));
         assert!(script.contains("challenges.cloudflare.com"));
-        assert!(script.contains("installGrokEngine"));
+        assert!(script.contains("function installEngineAndAdapter()"));
         assert!(script.contains("ADAPTER_UPDATE"));
         assert!(script.contains("CHECK_STATUS"));
+        assert!(script.contains("正在執行安全驗證"));
+        assert!(script.contains("bootId: String(window.__MAC_BRIDGE__.bootId || '')"));
+        let challenge_check = script
+            .find("if (challengeActive()) return { outcome: 'challenge' };")
+            .expect("driver must check the challenge");
+        let first_provider_write = script
+            .find("window.__MAC_PROVIDER__ =")
+            .expect("driver must eventually identify the provider");
+        assert!(challenge_check < first_provider_write);
+        serde_json::from_str::<serde_json::Value>(CHALLENGE_SIGNALS_JSON)
+            .expect("shared challenge signals must remain valid JSON");
     }
 
     #[test]
@@ -1598,61 +2052,83 @@ mod tests {
     }
 
     #[test]
-    fn grok_challenge_probe_is_read_only_and_bridge_passive() {
-        assert!(GROK_CHALLENGE_PROBE_JS.contains("!window.__MAC_BRIDGE__"));
-        assert!(GROK_CHALLENGE_PROBE_JS.contains("document.querySelector"));
-        assert!(GROK_CHALLENGE_PROBE_JS.contains("challenges.cloudflare.com"));
-        for mutation in [
-            "document.title =",
-            "history.",
-            "navigator.",
-            "MutationObserver",
-            "__MAC_BRIDGE__ =",
-        ] {
-            assert!(!GROK_CHALLENGE_PROBE_JS.contains(mutation));
-        }
+    fn grok_bridge_driver_callback_parses_only_known_outcomes() {
+        assert_eq!(
+            parse_grok_bridge_drive_outcome(r#""challenge""#),
+            Some(GrokBridgeDriveResult {
+                outcome: GrokBridgeDriveOutcome::Challenge,
+                boot_id: None,
+            })
+        );
+        assert_eq!(
+            parse_grok_bridge_drive_outcome(r#""\"installed\"""#),
+            Some(GrokBridgeDriveResult {
+                outcome: GrokBridgeDriveOutcome::Installed,
+                boot_id: None,
+            })
+        );
+        assert_eq!(
+            parse_grok_bridge_drive_outcome(
+                r#""{\"outcome\":\"present\",\"bootId\":\"boot-current\"}""#
+            ),
+            Some(GrokBridgeDriveResult {
+                outcome: GrokBridgeDriveOutcome::Present,
+                boot_id: Some("boot-current".into()),
+            })
+        );
+        assert_eq!(parse_grok_bridge_drive_outcome("null"), None);
+        assert_eq!(parse_grok_bridge_drive_outcome(r#""unexpected""#), None);
     }
 
     #[test]
-    fn grok_challenge_probe_targets_only_loaded_unblocked_grok() {
-        assert!(should_probe_grok_challenge(&state_with(
+    fn grok_bridge_watchdog_retries_loaded_unresolved_grok_including_blocked() {
+        assert!(should_drive_grok_bridge(&state_with(
             "grok", "loaded", "unknown", "unknown", false
         )));
-        assert!(should_probe_grok_challenge(&state_with(
+        assert!(should_drive_grok_bridge(&state_with(
+            "grok", "loaded", "unknown", "blocked", false
+        )));
+        assert!(!should_drive_grok_bridge(&state_with(
             "grok",
             "loaded",
             "ready",
             "logged_in",
             false
         )));
-        assert!(!should_probe_grok_challenge(&state_with(
-            "grok", "loaded", "unknown", "blocked", false
-        )));
-        assert!(!should_probe_grok_challenge(&state_with(
+        assert!(!should_drive_grok_bridge(&state_with(
             "grok", "creating", "unknown", "unknown", false
         )));
-        assert!(!should_probe_grok_challenge(&state_with(
+        assert!(!should_drive_grok_bridge(&state_with(
             "chatgpt", "loaded", "unknown", "unknown", false
+        )));
+        assert!(grok_bridge_drive_allowed(&state_with(
+            "grok", "creating", "unknown", "unknown", false
         )));
     }
 
     #[test]
-    fn stale_grok_challenge_probe_cannot_override_a_newer_state() {
-        let observed = state_with("grok", "loaded", "unknown", "unknown", false);
-        assert!(grok_challenge_probe_is_current(&observed, &observed));
+    fn stale_grok_bridge_driver_cannot_override_a_newer_document_or_ready_state() {
+        let unresolved = state_with("grok", "loaded", "unknown", "unknown", false);
+        assert_eq!(
+            grok_bridge_host_action(GrokBridgeDriveOutcome::Challenge, 4, 4, &unresolved),
+            GrokBridgeHostAction::MarkBlocked
+        );
+        assert_eq!(
+            grok_bridge_host_action(GrokBridgeDriveOutcome::Challenge, 3, 4, &unresolved),
+            GrokBridgeHostAction::Ignore
+        );
+        assert_eq!(
+            grok_bridge_host_action(GrokBridgeDriveOutcome::Waiting, 4, 4, &unresolved),
+            GrokBridgeHostAction::Ignore
+        );
 
-        let mut ready = observed.clone();
+        let mut ready = unresolved.clone();
         ready.dom = "ready".into();
         ready.login = "logged_in".into();
-        assert!(!grok_challenge_probe_is_current(&observed, &ready));
-
-        let mut newer = observed.clone();
-        newer.last_status_at = newer.last_status_at.saturating_add(1);
-        assert!(!grok_challenge_probe_is_current(&observed, &newer));
-
-        let mut blocked = observed.clone();
-        blocked.login = "blocked".into();
-        assert!(!grok_challenge_probe_is_current(&observed, &blocked));
+        assert_eq!(
+            grok_bridge_host_action(GrokBridgeDriveOutcome::Challenge, 4, 4, &ready),
+            GrokBridgeHostAction::Ignore
+        );
     }
 
     #[test]
@@ -1662,6 +2138,80 @@ mod tests {
         assert!(fresh_session_boot(None, Some("boot-a")));
         assert!(!fresh_session_boot(Some("boot-a"), None));
         assert!(!fresh_session_boot(None, None));
+    }
+
+    #[test]
+    fn grok_navigation_rejects_late_status_from_the_previous_document_boot() {
+        let _test_guard = GROK_RUNTIME_TEST_LOCK.lock().expect("Grok test lock");
+        let provider = "grok";
+        {
+            let mut guard = runtime().lock().expect("provider runtime lock");
+            guard.status_boot.remove(provider);
+            guard.grok_adopted_boot.remove(provider);
+            guard.grok_pending_navigation.remove(provider);
+            guard.grok_document_epoch.remove(provider);
+            guard.pending_session_boot.remove(provider);
+        }
+
+        let first_epoch = prepare_grok_navigation(provider);
+        assert_eq!(confirm_grok_page_load(provider), first_epoch);
+        assert!(adopt_grok_bridge_boot(provider, first_epoch, "old-boot"));
+        assert!(accept_status_for_session_reset(provider, Some("old-boot")));
+
+        let next_epoch = prepare_grok_navigation(provider);
+        assert!(!grok_bridge_result_is_current(provider, first_epoch));
+        assert!(!adopt_grok_bridge_boot(provider, first_epoch, "old-boot"));
+        assert!(!accept_status_for_session_reset(provider, Some("old-boot")));
+        assert_eq!(confirm_grok_page_load(provider), next_epoch);
+        assert!(!grok_bridge_result_is_current(provider, first_epoch));
+        assert!(!adopt_grok_bridge_boot(provider, first_epoch, "old-boot"));
+        assert!(adopt_grok_bridge_boot(provider, next_epoch, "new-boot"));
+        assert!(accept_status_for_session_reset(provider, Some("new-boot")));
+        assert!(accept_status_for_session_reset(provider, Some("new-boot")));
+
+        let restored_epoch = prepare_grok_navigation(provider);
+        assert_eq!(confirm_grok_page_load(provider), restored_epoch);
+        assert!(adopt_grok_bridge_boot(provider, restored_epoch, "old-boot"));
+        assert!(accept_status_for_session_reset(provider, Some("old-boot")));
+
+        let mut guard = runtime().lock().expect("provider runtime lock");
+        guard.status_boot.remove(provider);
+        guard.grok_adopted_boot.remove(provider);
+        guard.grok_pending_navigation.remove(provider);
+        guard.grok_document_epoch.remove(provider);
+    }
+
+    #[test]
+    fn failed_grok_navigation_restores_the_live_document_boot() {
+        let _test_guard = GROK_RUNTIME_TEST_LOCK.lock().expect("Grok test lock");
+        let provider = "grok";
+        {
+            let mut guard = runtime().lock().expect("provider runtime lock");
+            guard.status_boot.remove(provider);
+            guard.grok_adopted_boot.remove(provider);
+            guard.grok_pending_navigation.remove(provider);
+            guard.grok_document_epoch.remove(provider);
+            guard.pending_session_boot.remove(provider);
+        }
+
+        let live_epoch = prepare_grok_navigation(provider);
+        assert_eq!(confirm_grok_page_load(provider), live_epoch);
+        assert!(adopt_grok_bridge_boot(provider, live_epoch, "live-boot"));
+        assert!(accept_status_for_session_reset(provider, Some("live-boot")));
+
+        let failed_epoch = prepare_grok_navigation(provider);
+        assert!(!accept_status_for_session_reset(
+            provider,
+            Some("live-boot")
+        ));
+        cancel_grok_navigation(provider, failed_epoch);
+        assert!(accept_status_for_session_reset(provider, Some("live-boot")));
+
+        let mut guard = runtime().lock().expect("provider runtime lock");
+        guard.status_boot.remove(provider);
+        guard.grok_adopted_boot.remove(provider);
+        guard.grok_pending_navigation.remove(provider);
+        guard.grok_document_epoch.remove(provider);
     }
 
     #[test]

--- a/src-tauri/src/webviews.rs
+++ b/src-tauri/src/webviews.rs
@@ -69,6 +69,27 @@ fn provider_uses_permission_shim(provider: &str) -> bool {
     provider != "grok"
 }
 
+fn provider_uses_automation_browser_tuning(provider: &str) -> bool {
+    provider != "grok"
+}
+
+fn provider_uses_document_start_bridge(provider: &str) -> bool {
+    provider != "grok"
+}
+
+fn grok_app_title_ready(provider: &str, title: &str) -> bool {
+    if provider != "grok" {
+        return false;
+    }
+    let normalized = title.trim().to_lowercase();
+    normalized == "grok" || normalized.starts_with("grok - ") || normalized.starts_with("grok — ")
+}
+
+fn grok_bridge_install_ready(provider: &str, title: &str, url: &tauri::Url) -> bool {
+    grok_app_title_ready(provider, title)
+        && adapters::url_matches_provider_app(provider, url).unwrap_or(false)
+}
+
 fn grok_challenge_title_active(provider: &str, title: &str) -> bool {
     if provider != "grok" {
         return false;
@@ -81,6 +102,7 @@ fn grok_challenge_title_active(provider: &str, title: &str) -> bool {
         "performing security verification",
         "請稍候",
         "请稍候",
+        "安全驗證",
         "安全性驗證",
         "安全验证",
         "セキュリティ検証",
@@ -322,6 +344,11 @@ pub async fn provider_open(
         serde_json::to_string(&provider).map_err(|error| error.to_string())?,
         BOOTSTRAP_JS
     );
+    let delayed_grok_script = if provider == "grok" {
+        Some(delayed_grok_bridge_script(&provider)?)
+    } else {
+        None
+    };
     let nav_app = app.clone();
     let nav_provider = provider.clone();
     let popup_app = app.clone();
@@ -332,8 +359,15 @@ pub async fn provider_open(
     // the old Windows-only `register_title_watcher` (whose non-Windows branch was a no-op stub).
     let title_app = app.clone();
     let title_provider = provider.clone();
-    let builder =
-        WebviewBuilder::new(&label, WebviewUrl::External(url)).initialization_script(&init_script);
+    let title_delayed_grok_script = delayed_grok_script;
+    let builder = WebviewBuilder::new(&label, WebviewUrl::External(url));
+    // Grok's Cloudflare challenge must see a stock document from its first instruction.
+    // Install the automation bridge only after the real app page is confirmed below.
+    let builder = if provider_uses_document_start_bridge(&provider) {
+        builder.initialization_script(&init_script)
+    } else {
+        builder
+    };
     // Cloudflare Turnstile requires standard, unmodified browser APIs in embedded WebViews.
     // Grok is Cloudflare-protected, so do not monkey-patch navigator.permissions,
     // Notification, or geolocation in its top page or challenge frames.
@@ -342,12 +376,41 @@ pub async fn provider_open(
     } else {
         builder
     };
+    let builder = builder.data_directory(profile_dir);
+    // Keep Grok's challenge environment close to stock WebView2. Other providers retain
+    // background execution tuning for hidden workflow automation.
+    let builder = if provider_uses_automation_browser_tuning(&provider) {
+        builder
+            .background_throttling(BackgroundThrottlingPolicy::Disabled)
+            .additional_browser_args(PROVIDER_BROWSER_ARGS)
+    } else {
+        builder
+    };
     let builder = builder
-        .data_directory(profile_dir)
-        .background_throttling(BackgroundThrottlingPolicy::Disabled)
-        .additional_browser_args(PROVIDER_BROWSER_ARGS)
-        .on_document_title_changed(move |_webview, title| {
+        .on_document_title_changed(move |webview, title| {
             handle_provider_document_title(&title_app, &title_provider, &title);
+            let install_ready = webview
+                .url()
+                .ok()
+                .is_some_and(|url| grok_bridge_install_ready(&title_provider, &title, &url));
+            let Some(script) = title_delayed_grok_script.as_deref() else {
+                return;
+            };
+            if !install_ready {
+                return;
+            }
+
+            // A Turnstile iframe can leave the top-level title as "Grok". Require the
+            // read-only challenge probe to return an explicit false before installing.
+            // Use this event's WebView directly: title events may arrive before the
+            // child is discoverable through AppHandle's webview registry.
+            let install_webview = webview.clone();
+            let script = script.to_string();
+            let _ = webview.eval_with_callback(GROK_CHALLENGE_PROBE_JS, move |raw| {
+                if eval_callback_reports_false(&raw) {
+                    let _ = install_webview.eval(&script);
+                }
+            });
         })
         .on_navigation(move |url| {
             if url.host_str() == Some("mac-bridge.invalid") {
@@ -782,6 +845,50 @@ pub(crate) fn push_engine_and_adapter(app: &AppHandle, provider: &str) -> Result
     eval_provider(app, provider, &js)
 }
 
+fn delayed_grok_bridge_script(provider: &str) -> Result<String, String> {
+    let adapter = adapters::get_adapter(provider)?;
+    let provider_json = serde_json::to_string(provider).map_err(|error| error.to_string())?;
+    let dispatch_adapter = serde_json::json!({
+        "v": 1,
+        "action": "ADAPTER_UPDATE",
+        "provider": provider,
+        "payload": adapter
+    });
+    let dispatch_check = serde_json::json!({
+        "v": 1,
+        "action": "CHECK_STATUS",
+        "provider": provider
+    });
+    Ok(format!(
+        r#"if (
+  window.self === window.top &&
+  location.protocol === 'https:' &&
+  location.hostname === 'grok.com' &&
+  !document.querySelector('#challenge-running, #challenge-stage, #cf-challenge-running, form#challenge-form, .h-captcha, [data-hcaptcha-widget-id], iframe[src*="hcaptcha.com"], iframe[src*="challenges.cloudflare.com"]') &&
+  !window.__MAC_GROK_DELAYED_INSTALL__
+) {{
+  window.__MAC_GROK_DELAYED_INSTALL__ = true;
+  window.__MAC_PROVIDER__ = {provider_json};
+  {bootstrap}
+  (function installGrokEngine(attempt) {{
+    if (window.__MAC_BRIDGE__) {{
+      {engine}
+      window.__MAC_BRIDGE__.dispatch({adapter_msg});
+      window.__MAC_BRIDGE__.dispatch({check_msg});
+      return;
+    }}
+    if (attempt < 120) {{
+      window.setTimeout(function () {{ installGrokEngine(attempt + 1); }}, 250);
+    }}
+  }})(0);
+}}"#,
+        bootstrap = BOOTSTRAP_JS,
+        engine = ENGINE_JS,
+        adapter_msg = serde_json::to_string(&dispatch_adapter).map_err(|error| error.to_string())?,
+        check_msg = serde_json::to_string(&dispatch_check).map_err(|error| error.to_string())?,
+    ))
+}
+
 fn update_status_state(
     app: &AppHandle,
     provider: &str,
@@ -984,12 +1091,18 @@ fn fresh_session_boot(previous_boot: Option<&str>, incoming_boot: Option<&str>) 
 }
 
 fn eval_callback_reports_true(raw: &str) -> bool {
+    eval_callback_boolean(raw) == Some(true)
+}
+
+fn eval_callback_reports_false(raw: &str) -> bool {
+    eval_callback_boolean(raw) == Some(false)
+}
+
+fn eval_callback_boolean(raw: &str) -> Option<bool> {
     match serde_json::from_str::<serde_json::Value>(raw) {
-        Ok(serde_json::Value::Bool(value)) => value,
-        Ok(serde_json::Value::String(value)) => {
-            serde_json::from_str::<bool>(&value).unwrap_or(false)
-        }
-        _ => false,
+        Ok(serde_json::Value::Bool(value)) => Some(value),
+        Ok(serde_json::Value::String(value)) => serde_json::from_str::<bool>(&value).ok(),
+        _ => None,
     }
 }
 
@@ -1112,12 +1225,15 @@ mod tests {
     use super::{
         accept_status_for_session_reset, bridge_resets_on_boot_rotation, cancel_session_reset,
         challenge_auxiliary_navigation_allowed, decide_new_window_action,
-        eval_callback_reports_true, fresh_session_boot, gemini_sorry_navigation_active,
-        grok_challenge_probe_is_current, grok_challenge_title_active, physical_bounds,
-        popup_initial_title, provider_show_should_focus, provider_uses_permission_shim, runtime,
-        should_probe_grok_challenge, should_reset_bridge_on_boot_rotation, staleness_action,
-        state_with, Bounds, NewWindowAction, StalenessAction, GROK_CHALLENGE_PROBE_JS,
-        PERMISSION_SHIM_JS, PROVIDER_BROWSER_ARGS,
+        delayed_grok_bridge_script, eval_callback_reports_false, eval_callback_reports_true,
+        fresh_session_boot, gemini_sorry_navigation_active, grok_app_title_ready,
+        grok_bridge_install_ready, grok_challenge_probe_is_current, grok_challenge_title_active,
+        physical_bounds, popup_initial_title, provider_show_should_focus,
+        provider_uses_automation_browser_tuning, provider_uses_document_start_bridge,
+        provider_uses_permission_shim, runtime, should_probe_grok_challenge,
+        should_reset_bridge_on_boot_rotation, staleness_action, state_with, Bounds,
+        NewWindowAction, StalenessAction, GROK_CHALLENGE_PROBE_JS, PERMISSION_SHIM_JS,
+        PROVIDER_BROWSER_ARGS,
     };
 
     fn url(input: &str) -> tauri::Url {
@@ -1142,9 +1258,44 @@ mod tests {
     #[test]
     fn grok_keeps_core_web_apis_unmodified_for_cloudflare_challenges() {
         assert!(!provider_uses_permission_shim("grok"));
+        assert!(!provider_uses_automation_browser_tuning("grok"));
+        assert!(!provider_uses_document_start_bridge("grok"));
         for provider in ["chatgpt", "claude", "gemini"] {
             assert!(provider_uses_permission_shim(provider));
+            assert!(provider_uses_automation_browser_tuning(provider));
+            assert!(provider_uses_document_start_bridge(provider));
         }
+    }
+
+    #[test]
+    fn grok_bridge_waits_for_the_real_app_and_a_negative_challenge_probe() {
+        assert!(grok_app_title_ready("grok", "Grok"));
+        assert!(grok_app_title_ready("grok", "Grok — Home"));
+        assert!(!grok_app_title_ready("grok", "grok.com 正在執行安全驗證"));
+        assert!(!grok_app_title_ready("grok", "Just a moment..."));
+        assert!(!grok_app_title_ready("chatgpt", "Grok"));
+        assert!(grok_bridge_install_ready(
+            "grok",
+            "Grok",
+            &url("https://grok.com/")
+        ));
+        assert!(!grok_bridge_install_ready(
+            "grok",
+            "Grok",
+            &url("https://accounts.x.ai/sign-in")
+        ));
+        assert!(!eval_callback_reports_false("null"));
+        assert!(!eval_callback_reports_false(r#""unexpected""#));
+        assert!(eval_callback_reports_false("false"));
+        assert!(eval_callback_reports_false(r#""false""#));
+
+        let script = delayed_grok_bridge_script("grok").expect("delayed script should build");
+        assert!(script.contains("__MAC_GROK_DELAYED_INSTALL__"));
+        assert!(script.contains("location.hostname === 'grok.com'"));
+        assert!(script.contains("challenges.cloudflare.com"));
+        assert!(script.contains("installGrokEngine"));
+        assert!(script.contains("ADAPTER_UPDATE"));
+        assert!(script.contains("CHECK_STATUS"));
     }
 
     #[test]
@@ -1432,6 +1583,7 @@ mod tests {
         for title in [
             "Just a moment...",
             "Performing security verification",
+            "grok.com 正在執行安全驗證",
             "安全性驗證",
             "セキュリティ検証",
             "Sicherheitsüberprüfung",

--- a/src/__tests__/engine-input.test.ts
+++ b/src/__tests__/engine-input.test.ts
@@ -50,13 +50,13 @@ describe('injected engine input hardening', () => {
     vi.resetModules();
   });
 
-  it('reports a Grok challenge as blocked when an already-running engine sees it', async () => {
+  it('reports a Grok challenge before a stale composer can claim logged-in', async () => {
     vi.useFakeTimers();
     const env = createEnv({ inputKind: 'textarea' });
     env.cloudflareChallenge = true;
     const handler = await installEngine(env);
 
-    dispatchAdapter(handler, { loginDetectors: [], loggedOutDetectors: [] });
+    dispatchAdapter(handler);
 
     expect(env.emitted).toContainEqual({
       v: 1,
@@ -64,6 +64,182 @@ describe('injected engine input hardening', () => {
       provider: 'grok',
       payload: { dom: 'ready', login: 'blocked', thinking: false, bootId: 'boot1' },
     });
+  });
+
+  it('refuses SEND_MESSAGE without mutating the challenge document', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea' });
+    const handler = await installEngine(env);
+    dispatchAdapter(handler);
+    env.cloudflareChallenge = true;
+
+    send(handler, 'must not land');
+    await vi.advanceTimersByTimeAsync(PRE_SEND_DELAY_MS + SEND_RETRY_DELAY_MS);
+
+    expect(env.input.textContent).toBe('');
+    expect(env.sendButton?.clickCount).toBe(0);
+    expect(keyEventCount(env.input)).toBe(0);
+    expect(errorDone(env)?.payload).toBe('[Error: grok security challenge is active]');
+    expect(env.emitted).toContainEqual({
+      v: 1,
+      action: 'STATUS_REPORT',
+      provider: 'grok',
+      payload: { dom: 'ready', login: 'blocked', thinking: false, bootId: 'boot1' },
+    });
+  });
+
+  it('emits one challenge error for two queued SEND_MESSAGE commands', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea' });
+    const handler = await installEngine(env);
+    dispatchAdapter(handler);
+    env.cloudflareChallenge = true;
+
+    send(handler, 'first queued send');
+    send(handler, 'second queued send');
+    await flushMicrotasks();
+
+    expect(
+      env.emitted.filter(
+        (message) => message.action === 'RESPONSE_DONE' && message.payload === '[Error: grok security challenge is active]',
+      ),
+    ).toHaveLength(1);
+    expect(env.input.textContent).toBe('');
+  });
+
+  it('rejects an overlapping SEND_MESSAGE while the first send is being staged', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea' });
+    const handler = await installEngine(env);
+    dispatchAdapter(handler);
+
+    send(handler, 'first queued send');
+    send(handler, 'second queued send');
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(PRE_SEND_DELAY_MS);
+
+    expect(env.input.textContent).toBe('first queued send');
+    expect(env.sendButton?.clickCount).toBe(1);
+    expect(env.emitted.filter((message) => message.action === 'RESPONSE_DONE')).toHaveLength(0);
+  });
+
+  it('serializes same-tick SEND_MESSAGE and FILL_DRAFT staging', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea' });
+    const handler = await installEngine(env);
+    dispatchAdapter(handler);
+
+    send(handler, 'send wins');
+    fill(handler, 'fill must wait');
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(PRE_SEND_DELAY_MS);
+
+    expect(env.input.textContent).toBe('send wins');
+    expect(env.sendButton?.clickCount).toBe(1);
+  });
+
+  it('serializes same-tick FILL_DRAFT and SEND_MESSAGE staging', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea' });
+    const handler = await installEngine(env);
+    dispatchAdapter(handler);
+
+    fill(handler, 'fill wins');
+    send(handler, 'send must wait');
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(PRE_SEND_DELAY_MS);
+
+    expect(env.input.textContent).toBe('fill wins');
+    expect(env.sendButton?.clickCount).toBe(0);
+  });
+
+  it('refuses FILL_DRAFT without mutation or an unsolicited error DONE', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea' });
+    const handler = await installEngine(env);
+    dispatchAdapter(handler);
+    env.cloudflareChallenge = true;
+
+    fill(handler, 'must not land');
+    await flushMicrotasks();
+
+    expect(env.input.textContent).toBe('');
+    expect(env.sendButton?.clickCount).toBe(0);
+    expect(keyEventCount(env.input)).toBe(0);
+    expect(errorDone(env)).toBeUndefined();
+  });
+
+  it('does not click or press Enter when a challenge appears during the pre-send delay', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea' });
+    const handler = await installEngine(env);
+    dispatchAdapter(handler);
+
+    send(handler, 'staged before challenge');
+    await flushMicrotasks();
+    expect(env.input.textContent).toBe('staged before challenge');
+
+    env.cloudflareChallenge = true;
+    await vi.advanceTimersByTimeAsync(PRE_SEND_DELAY_MS);
+
+    expect(env.sendButton?.clickCount).toBe(0);
+    expect(keyEventCount(env.input)).toBe(0);
+    expect(errorDone(env)?.payload).toBe('[Error: grok security challenge is active]');
+  });
+
+  it('stops async input fallbacks when a challenge appears at a strategy yield', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'contenteditable' });
+    env.input.onDispatch = (event) => {
+      if (event.type === 'paste') {
+        void Promise.resolve().then(() => {
+          env.cloudflareChallenge = true;
+        });
+      }
+    };
+    const handler = await installEngine(env);
+    dispatchAdapter(handler, { inputStrategy: 'prosemirror-paste' });
+
+    send(handler, 'must not reach a fallback');
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(env.input.textContent).toBe('');
+    expect(env.sendButton?.clickCount).toBe(0);
+    expect(keyEventCount(env.input)).toBe(0);
+    expect(
+      env.emitted.filter(
+        (message) => message.action === 'RESPONSE_DONE' && message.payload === '[Error: grok security challenge is active]',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('releases a FILL_DRAFT response wait when a challenge appears at a strategy yield', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'contenteditable' });
+    env.input.onDispatch = (event) => {
+      if (event.type === 'paste') {
+        void Promise.resolve().then(() => {
+          env.cloudflareChallenge = true;
+        });
+      }
+    };
+    const handler = await installEngine(env);
+    dispatchAdapter(handler, { inputStrategy: 'prosemirror-paste' });
+
+    fill(handler, 'blocked fill');
+    await flushMicrotasks();
+    await flushMicrotasks();
+    env.cloudflareChallenge = false;
+    env.input.onDispatch = undefined;
+
+    send(handler, 'later send');
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(PRE_SEND_DELAY_MS);
+
+    expect(env.input.textContent).toBe('later send');
+    expect(env.sendButton?.clickCount).toBe(1);
+    expect(errorDone(env)).toBeUndefined();
   });
 
   it('reports ChatGPT logged out when login controls and a stale composer coexist', async () => {
@@ -418,6 +594,127 @@ describe('injected engine input hardening', () => {
 
     await vi.advanceTimersByTimeAsync(1);
     expect(errorDone(env)?.payload).toBe('[Error: grok send activation failed: enter key dispatch failed]');
+  });
+
+  it('emits only one terminal error when a challenge appears during retry lookup', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea', sendButton: null });
+    const handler = await installEngine(env);
+    dispatchAdapter(handler);
+
+    send(handler, 'hello');
+    await vi.advanceTimersByTimeAsync(PRE_SEND_DELAY_MS + SEND_BUTTON_SELECTOR_TIMEOUT_MS);
+    await vi.advanceTimersByTimeAsync(SEND_RETRY_DELAY_MS);
+    env.cloudflareChallenge = true;
+    await vi.advanceTimersByTimeAsync(SEND_BUTTON_SELECTOR_TIMEOUT_MS);
+    await flushMicrotasks();
+
+    expect(
+      env.emitted.filter(
+        (message) => message.action === 'RESPONSE_DONE' && message.payload === '[Error: grok security challenge is active]',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('does not let a stale pre-send timer act on a later send operation', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea' });
+    const handler = await installEngine(env);
+    dispatchAdapter(handler, {
+      timing: {
+        doneDelayMs: 10,
+        chunkDebounceMs: 0,
+        statusIntervalMs: 1_000_000,
+        backupPollMs: 10,
+      },
+    });
+
+    send(handler, 'first draft');
+    await flushMicrotasks();
+    env.responses = [new FakeElement(env.document, 'div', 'first answer')];
+    await vi.advanceTimersByTimeAsync(20);
+    expect(env.emitted.filter((message) => message.action === 'RESPONSE_DONE')).toHaveLength(1);
+
+    send(handler, 'second draft');
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(PRE_SEND_DELAY_MS);
+
+    expect(env.input.textContent).toBe('second draft');
+    expect(env.sendButton?.clickCount).toBe(1);
+  });
+
+  it('does not let a stale delayed finish terminate a later response wait', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea' });
+    const handler = await installEngine(env);
+    dispatchAdapter(handler, {
+      thinkingDetectors: ['.thinking'],
+      timing: {
+        doneDelayMs: 1_000,
+        chunkDebounceMs: 0,
+        statusIntervalMs: 1_000_000,
+        backupPollMs: 10,
+      },
+    });
+
+    env.thinking = true;
+    send(handler, 'first draft');
+    await flushMicrotasks();
+    env.responses = [new FakeElement(env.document, 'div', 'first answer')];
+    await vi.advanceTimersByTimeAsync(1_010);
+    env.thinking = false;
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    env.cloudflareChallenge = true;
+    await vi.advanceTimersByTimeAsync(500);
+    expect(errorDone(env)?.payload).toBe('[Error: grok security challenge is active]');
+
+    env.cloudflareChallenge = false;
+    await flushMicrotasks();
+    send(handler, 'second draft');
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(env.emitted.filter((message) => message.action === 'RESPONSE_DONE')).toHaveLength(1);
+    expect(env.input.textContent).toBe('second draft');
+  });
+
+  it('renews the stability window when text arrives after thinking stops', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea' });
+    const handler = await installEngine(env);
+    dispatchAdapter(handler, {
+      thinkingDetectors: ['.thinking'],
+      timing: {
+        doneDelayMs: 100,
+        chunkDebounceMs: 0,
+        statusIntervalMs: 1_000_000,
+        backupPollMs: 10,
+      },
+    });
+
+    env.thinking = true;
+    send(handler, 'draft');
+    await flushMicrotasks();
+    const response = new FakeElement(env.document, 'div', 'partial answer');
+    env.responses = [response];
+    await vi.advanceTimersByTimeAsync(110);
+
+    env.thinking = false;
+    await vi.advanceTimersByTimeAsync(1_000);
+    response.textContent = 'complete answer';
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(90);
+
+    expect(env.emitted.filter((message) => message.action === 'RESPONSE_DONE')).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(env.emitted).toContainEqual({
+      v: 1,
+      action: 'RESPONSE_DONE',
+      provider: 'grok',
+      payload: 'complete answer',
+    });
   });
 
   it('FILL_DRAFT inserts text without clicking send, dispatching Enter, or scheduling send retry', async () => {
@@ -921,6 +1218,14 @@ class FakeDocument {
     return {
       selectNodeContents(_el: Element) {
         // no-op for fake selection
+      },
+    };
+  }
+
+  createTreeWalker(_root: FakeElement, _whatToShow: number) {
+    return {
+      nextNode() {
+        return null;
       },
     };
   }

--- a/src/__tests__/pull.test.ts
+++ b/src/__tests__/pull.test.ts
@@ -254,6 +254,7 @@ describe('bootstrap outbox helpers', () => {
     expect(hasCloudflareChallengeSignals('Grok', 'Please complete the security check', false)).toBe(true);
     expect(hasCloudflareChallengeSignals('Grok', '人間であることを確認しています', false)).toBe(true);
     expect(hasCloudflareChallengeSignals('請稍候…', '', false)).toBe(true);
+    expect(hasCloudflareChallengeSignals('grok.com 正在執行安全驗證', '', false)).toBe(true);
     expect(hasCloudflareChallengeSignals('Grok', '驗證您是人類 grok.com', false)).toBe(true);
     expect(hasCloudflareChallengeSignals('Grok', '正在驗證您是否為真人', false)).toBe(true);
     expect(hasCloudflareChallengeSignals('Grok', 'Ready to chat', true)).toBe(true);


### PR DESCRIPTION
## Summary

- Keep Grok's Cloudflare/Turnstile document stock by omitting the document-start automation bridge and permission shim for Grok, while retaining the background-liveness settings used by hidden provider panes.
- Use one atomic, top-frame `https://grok.com` driver that checks shared Cloudflare/hCaptcha title, body, and marker signals before it writes provider globals or installs the bridge.
- Retry unresolved and blocked Grok documents through title events, page-load completion, and the host watchdog.
- Bind accepted Grok title traffic to the bridge boot positively observed in the current document epoch. Rejected stale titles cannot rotate the title transport or reach the frontend.
- Refuse fill, send, and stop mutations while a challenge is active. Serialize overlapping SEND/FILL staging and scope delayed callbacks to their response/send generation.
- Recognize the observed Traditional Chinese `安全驗證` title through a shared signal source used by TypeScript and Rust.

This is a follow-up to #54 and the live limitation described in #53. It does not automate, bypass, or weaken Turnstile.

## Validation

- [x] `pnpm verify` — 461 app tests and 22 agent-contract tests passed; injected build, typecheck, lint, and adapter checks passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --all-targets` — 67 passed
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- [x] `pnpm build`
- [x] GitHub CI — frontend plus Windows, macOS, and Linux Rust jobs passed
- [x] Focused regression coverage for stale document/title callbacks, failed navigation rollback, BFCache boot adoption, overlapping SEND/FILL commands, duplicate challenge DONEs, and stale response timers
- [x] No cookies, tokens, account data, conversation text, provider HTML, or local profile files are included

### Manual evidence and release-risk decision

- Earlier prototype evidence: Windows 11, WebView2 Runtime `150.0.4078.99`, Grok adapter v7, fresh isolated provider profile; the prototype completed the live Cloudflare challenge and allowed embedded Grok login.
- The final isolated configuration was **not** retested with a live Grok account. Turnstile completion, UI Ready state, prompt send, response capture, reload, new-session behavior, and non-Windows live behavior therefore remain unverified.
- On 2026-07-28, the project owner explicitly accepted this unverified risk and requested release. This decision is not represented as manual test evidence.

## Adapter changes

Not applicable; no adapter or URL scope changed.
