### PR TITLE
fix: point blocked-banner copy at the in-pane challenge now that it is solvable

### DIFF
--- a/src/__tests__/FocusPaneHeader.test.tsx
+++ b/src/__tests__/FocusPaneHeader.test.tsx
@@ -115,15 +115,19 @@ describe('FocusPane provider header', () => {
     expect(html).not.toContain('aria-label="ChatGPT: Ready · Currently reading"');
   });
 
-  it('offers an honest browser escape hatch when Grok embedded login is blocked', () => {
+  it('points the user at the in-pane challenge when Grok is blocked, keeping the browser as a fallback only', () => {
     const html = renderFocusPane({
       centeredProvider: 'grok',
       stateOverrides: { grok: { login: 'blocked' } },
     });
 
     expect(html).toContain(
-      'Security checks on this site prevent sign-in within the app. Use this AI in your browser, or retry this page later.',
+      'This site is running a security check. Complete it in this pane; if the status does not update afterwards, reload.',
     );
+    // The challenge is solvable in the embedded webview now that the app keeps
+    // script evaluation out of challenge documents. Copy that sends the user to
+    // the browser instead makes them abandon a login that would have worked.
+    expect(html).not.toContain('Use this AI in your browser');
     expect(html).toContain('Open in browser');
   });
 

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -120,7 +120,7 @@ export const de: Record<I18nKey, string> = {
   'provider.report': 'Melden',
   'provider.adapterBroken': 'Adapter defekt',
   'provider.bridgeDegradedReload': 'Bridge beeinträchtigt. Neu laden empfohlen.',
-  'provider.embeddedLoginBlocked': 'Die Sicherheitsprüfung der Website blockiert die Anmeldung in der App. Diese KI im Browser nutzen oder diese Seite später erneut versuchen.',
+  'provider.embeddedLoginBlocked': 'Die Website führt eine Sicherheitsprüfung durch. Schließen Sie sie in diesem Bereich ab; wird der Status danach nicht aktualisiert, laden Sie neu.',
   'provider.openInBrowser': 'Im Browser öffnen',
   'provider.nativeWebviewHidden': 'Natives Webview ausgeblendet; die Hintergrundaktivität läuft weiter.',
   'provider.nativeWebviewMounted': 'Natives Webview wird hier angezeigt',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -118,7 +118,7 @@ export const en: Record<I18nKey, string> = {
   'provider.report': 'Report',
   'provider.adapterBroken': 'Adapter broken',
   'provider.bridgeDegradedReload': 'Bridge degraded. Reload suggested.',
-  'provider.embeddedLoginBlocked': 'Security checks on this site prevent sign-in within the app. Use this AI in your browser, or retry this page later.',
+  'provider.embeddedLoginBlocked': 'This site is running a security check. Complete it in this pane; if the status does not update afterwards, reload.',
   'provider.openInBrowser': 'Open in browser',
   'provider.nativeWebviewHidden': 'Native webview hidden; background activity continues.',
   'provider.nativeWebviewMounted': 'Native webview mounted here',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -120,7 +120,7 @@ export const ja: Record<I18nKey, string> = {
   'provider.report': '報告',
   'provider.adapterBroken': 'アダプター破損',
   'provider.bridgeDegradedReload': 'ブリッジに問題があります。再読み込みをお勧めします。',
-  'provider.embeddedLoginBlocked': 'サイトのセキュリティ検証により、アプリ内でのログインがブロックされています。ブラウザーでこの AI をご利用いただくか、後でもう一度このページをお試しください。',
+  'provider.embeddedLoginBlocked': 'サイトがセキュリティ検証を実行中です。このパネル内で完了してください。完了後に状態が更新されない場合は再読み込みしてください。',
   'provider.openInBrowser': 'ブラウザーで開く',
   'provider.nativeWebviewHidden': 'ネイティブWebviewは非表示です。バックグラウンド処理は続行します。',
   'provider.nativeWebviewMounted': 'ネイティブWebviewをここに表示中',

--- a/src/i18n/zh-TW.ts
+++ b/src/i18n/zh-TW.ts
@@ -108,7 +108,7 @@ export const zhTW: Record<I18nKey, string> = {
   'provider.report': '回報',
   'provider.adapterBroken': 'Adapter 異常',
   'provider.bridgeDegradedReload': '橋接降級。建議重新載入。',
-  'provider.embeddedLoginBlocked': '網站的安全驗證擋下了 app 內登入。請改在瀏覽器使用這個 AI，或稍後重試此頁面。',
+  'provider.embeddedLoginBlocked': '網站正在進行安全驗證。請在此面板完成驗證；完成後若狀態未更新，重新載入即可。',
   'provider.openInBrowser': '在瀏覽器開啟',
   'provider.nativeWebviewHidden': '原生 webview 已隱藏；背景活動會繼續。',
   'provider.nativeWebviewMounted': '原生 webview 已掛載於此',


### PR DESCRIPTION
## Problem

The blocked banner (shown for Gemini and Grok when `login === 'blocked'`) reads:

> Security checks on this site prevent sign-in within the app. Use this AI in your browser, or retry this page later.

That was accurate when it was written in #48: an embedded Grok login genuinely could not be completed, because the Turnstile challenge reissued itself indefinitely and never produced a solvable widget. Directing the user to a real browser was the only honest advice available.

It is no longer accurate. Live retest on Windows 11 Pro 26200 (zh-TW, local build of `a1aee84`, existing per-provider profiles) — reported in #59:

- the Turnstile challenge presents a solvable widget and stays put,
- Grok login completes in the embedded webview (via Google OAuth, which previously opened a blank window),
- the session persists, and all four providers send prompts and capture responses.

So the banner now tells users to abandon a login that would have worked, at exactly the moment they are looking at a challenge they could solve.

## Cause

The copy encodes the old diagnosis — that Cloudflare was rejecting the embedded WebView environment as such, making in-app login impossible. #57 and #58 established the real cause (the app's own script evaluation into challenge documents read as tampering) and fixed it. The user-facing copy was not revisited afterwards, so it still describes the pre-fix world.

## Fix

Point the banner at the challenge in front of the user instead:

> This site is running a security check. Complete it in this pane; if the status does not update afterwards, reload.

- The second clause is a deliberate workaround for #59: after login completes, the provider can stay not-ready until the pane is reloaded. Until that recovery path is addressed, telling the user to reload is more useful than leaving them stuck at a stale status.
- **"Open in browser" is unchanged and stays.** It remains the right fallback for challenges that genuinely cannot be completed in-app — the Gemini `/sorry` path shares this banner, and Grok challenges may still be unsolvable on some networks or accounts.
- All four locales updated (zh-TW, en, ja, de).
- The `provider.embeddedLoginBlocked` key name is left alone; renaming it would touch `keys.ts` and every locale for no user-visible gain.

The regression test in `src/__tests__/FocusPaneHeader.test.tsx` now also asserts the defeatist sentence is absent, so a revert to "use this AI in your browser" copy fails the suite instead of silently returning. The comment above that assertion records why, since the reason lives in #57/#58 rather than in this diff.

## Verification

- `pnpm verify` — passes: `build:injected`, `typecheck`, `lint`, 53 test files / 465 tests, `agent:verify` (22), `check-adapters`. Run on Windows.
- No Rust code touched, so no `cargo` runs were needed.
- The copy change itself was not re-observed in a live challenge banner: reaching the blocked state on demand requires an unsolved challenge, which is not reproducible to order now that the challenge completes. The rendered-output assertion in `FocusPaneHeader.test.tsx` covers the banner text and the button.

Locale note: the English string avoids apostrophes, since React escapes them to `&#x27;` and breaks `toContain` assertions on the rendered HTML.

No cookies, tokens, account data, conversation text, provider HTML, or profile files are included, per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
