### PR TITLE
fix: collect the whole answer -- finish-time re-read, unfinished-turn signal, and $&-safe code blocks

### DIFF
--- a/injected/engine.ts
+++ b/injected/engine.ts
@@ -67,6 +67,28 @@ const USER_MESSAGE_ANCESTOR_SELECTOR = [
   '.message-bubble.user',
 ].join(', ');
 
+// A finished ChatGPT turn grows a copy button, without needing hover. The stop button is removed
+// before the last render batch lands, and multi-step answers (search, reasoning) can drop it
+// entirely during an intermediate pause, so relying on it alone reads a pause as "finished".
+// This second signal covers the window the stop button cannot see.
+//
+// This lives in the engine rather than the adapter JSON on purpose: thinkingDetectors is a flat
+// selector array that cannot express "the last turn is missing this element", and its seed values
+// are pinned by the SPEC 5.1 frozen table and by scripts/check-adapters.mjs.
+const TURN_COMPLETION_SIGNALS: Partial<Record<AIProvider, { turn: string; complete: string }>> = {
+  chatgpt: {
+    turn: '[data-testid^="conversation-turn-"]',
+    complete: '[data-testid="copy-turn-action-button"]',
+  },
+};
+
+// Ceiling on the signal above. If the copy-button testid is renamed, "still generating" would
+// latch forever, and because the host keepalive refreshes on every thinking report it would hold
+// the step open to its 60-minute absolute cap. So trust the signal only while the response text is
+// still fresh; past that, let the response finish on the ordinary path. Raising this trades a
+// longer worst-case wait for a smaller chance of cutting a slow multi-step answer short.
+const TURN_INCOMPLETE_GRACE_MS = 30_000;
+
 export function isLikelyPromptEcho(responseText: string, promptText: string): boolean {
   const trimmedResponse = responseText.trim();
   const trimmedPrompt = promptText.trim();
@@ -163,6 +185,7 @@ class InactiveSendOperationError extends Error {
   let activeSendOperation: number | undefined;
   let draftStaging = false;
   let lastResponseText = '';
+  let lastResponseChangeAt = 0;
   let pendingPromptText = '';
   let lastChunkTime = 0;
 
@@ -288,7 +311,7 @@ class InactiveSendOperationError extends Error {
       v: 1,
       action: 'STATUS_REPORT',
       provider: adapter.provider,
-      payload: { dom: 'ready', login, thinking: isThinking(), bootId: bridge.bootId },
+      payload: { dom: 'ready', login, thinking: isGenerating(), bootId: bridge.bootId },
     });
   }
 
@@ -401,6 +424,7 @@ class InactiveSendOperationError extends Error {
     activeResponseGeneration = responseGeneration;
     waitingForResponse = true;
     lastResponseText = '';
+    lastResponseChangeAt = Date.now();
     pendingPromptText = text;
     startResponsePolling();
 
@@ -804,21 +828,40 @@ class InactiveSendOperationError extends Error {
     return hasDetector(adapter?.thinkingDetectors);
   }
 
+  // Response completion asks this instead of isThinking(). The split is deliberate: sendStarted()
+  // uses isThinking() to decide whether a send landed, and right after a send the last turn is the
+  // user message, which carries no copy button. Letting the turn signal reach sendStarted() would
+  // make a failed send look accepted and leave the step waiting on a response that never comes.
+  function isGenerating(): boolean {
+    return isThinking() || lastTurnIncomplete();
+  }
+
+  function lastTurnIncomplete(): boolean {
+    if (!waitingForResponse || !adapter) return false;
+    const signal = TURN_COMPLETION_SIGNALS[adapter.provider];
+    if (!signal) return false;
+    if (Date.now() - lastResponseChangeAt > TURN_INCOMPLETE_GRACE_MS) return false;
+    const turns = document.querySelectorAll(signal.turn);
+    const lastTurn = turns.length > 0 ? turns[turns.length - 1] : null;
+    if (!lastTurn || typeof lastTurn.querySelector !== 'function') return false;
+    return !lastTurn.querySelector(signal.complete);
+  }
+
   function checkIfDone(expectedGeneration = activeResponseGeneration) {
     if (!waitingForResponse || expectedGeneration !== activeResponseGeneration) return;
-    if (isThinking()) {
+    if (isGenerating()) {
       if (checkDoneInterval === undefined) {
         checkDoneInterval = window.setInterval(() => {
           if (!waitingForResponse || expectedGeneration !== activeResponseGeneration) {
             clearCheckDone();
             return;
           }
-          if (!isThinking()) {
+          if (!isGenerating()) {
             clearCheckDone();
             finishResponseTimeout = window.setTimeout(() => {
               finishResponseTimeout = undefined;
               if (!waitingForResponse || expectedGeneration !== activeResponseGeneration) return;
-              if (isThinking()) {
+              if (isGenerating()) {
                 checkIfDone(expectedGeneration);
                 return;
               }
@@ -881,6 +924,7 @@ class InactiveSendOperationError extends Error {
       if (!currentText || currentText === lastResponseText) return;
       clearFinishResponseTimeout();
       lastResponseText = currentText;
+      lastResponseChangeAt = Date.now();
 
       const now = Date.now();
       if (now - lastChunkTime >= timing('chunkDebounceMs', 500)) {
@@ -910,6 +954,7 @@ class InactiveSendOperationError extends Error {
       if (!currentText || currentText === lastResponseText) return;
       clearFinishResponseTimeout();
       lastResponseText = currentText;
+      lastResponseChangeAt = Date.now();
       if (adapter) bridge.emit({ v: 1, action: 'RESPONSE_CHUNK', provider: adapter.provider, payload: currentText });
       if (responseTimeout !== undefined) window.clearTimeout(responseTimeout);
       const expectedGeneration = activeResponseGeneration;

--- a/injected/engine.ts
+++ b/injected/engine.ts
@@ -1,7 +1,7 @@
 import type { AIProvider, BridgeMessage } from '../shared/types';
 import { isProviderChallengeActive } from './challenge';
 import { buildReportDigest, type ReportElement } from './reportDigest';
-import { serializeResponseText } from './responseSerializer';
+import { longerResponseText, serializeResponseText } from './responseSerializer';
 
 type InputStrategyName = 'default' | 'prosemirror-paste' | 'quill-angular';
 type SendStrategy = 'click' | 'enter';
@@ -822,8 +822,6 @@ class InactiveSendOperationError extends Error {
                 checkIfDone(expectedGeneration);
                 return;
               }
-              const finalText = getLatestResponseText();
-              if (finalText) lastResponseText = finalText;
               finishResponse(expectedGeneration);
             }, timing('doneDelayMs', 3000));
           }
@@ -836,7 +834,9 @@ class InactiveSendOperationError extends Error {
 
   function finishResponse(expectedGeneration = activeResponseGeneration) {
     if (!waitingForResponse || expectedGeneration !== activeResponseGeneration || !adapter) return;
-    const payload = lastResponseText;
+    // 一定要在 cancelResponseWait() 之前重讀：getLatestResponseText 的 baseline 過濾靠
+    // waitingForResponse 與 responseBaselineEls，重置後會撈到送出前就存在的舊訊息。
+    const payload = longerResponseText(lastResponseText, getLatestResponseText());
     const sendOperation = activeSendOperation;
     cancelResponseWait();
     bridge.emit({ v: 1, action: 'RESPONSE_DONE', provider: adapter.provider, payload });

--- a/injected/engine.ts
+++ b/injected/engine.ts
@@ -834,8 +834,9 @@ class InactiveSendOperationError extends Error {
 
   function finishResponse(expectedGeneration = activeResponseGeneration) {
     if (!waitingForResponse || expectedGeneration !== activeResponseGeneration || !adapter) return;
-    // 一定要在 cancelResponseWait() 之前重讀：getLatestResponseText 的 baseline 過濾靠
-    // waitingForResponse 與 responseBaselineEls，重置後會撈到送出前就存在的舊訊息。
+    // Must re-read before cancelResponseWait(): getLatestResponseText filters the send-time
+    // baseline through waitingForResponse and responseBaselineEls, so after the reset it would
+    // return a message that already existed before the send.
     const payload = longerResponseText(lastResponseText, getLatestResponseText());
     const sendOperation = activeSendOperation;
     cancelResponseWait();

--- a/injected/responseSerializer.ts
+++ b/injected/responseSerializer.ts
@@ -26,9 +26,11 @@ interface SerializationContext {
   protectedBlocks: string[];
 }
 
-// 收尾時要送哪一份文字。ChatGPT 實測：停止鍵消失的當下回應只有 39 字，1.07 秒後才長到完整的
-// 301 字——「生成中」的訊號比最後一批 render 早結束，只送串流途中快取的文字就會少一截，
-// 極端情況（快取只抓到開頭那行）等於整篇只剩一行。串流是純附加，取較長的那份即可。
+// Which text to send when a response finishes. Measured against ChatGPT: the answer was 39
+// characters at the moment the stop button disappeared and 301 characters 1.07s later. The
+// "still generating" signal ends before the last render batch, so sending only the text cached
+// during streaming loses the tail — and when the cache holds just the opening line, that line
+// becomes the whole answer. Streaming is append-only, so the longer text is the complete one.
 export function longerResponseText(cached: string, fresh: string | null): string {
   return fresh && fresh.length > cached.length ? fresh : cached;
 }
@@ -36,8 +38,8 @@ export function longerResponseText(cached: string, fresh: string | null): string
 export function serializeResponseText(root: Element): string {
   const context: SerializationContext = { protectedBlocks: [] };
   const serialized = normalizeDocument(serializeNode(root, context));
-  // 用 replacer function 而不是字串：程式碼區塊裡的 $&、$'、$` 會被 String.replace 當成
-  // 特殊樣式展開，把整段程式碼換成別的內容。
+  // A replacer function, not a replacement string: $&, $', $` and $$ inside a code block are
+  // expanded by String.replace substitution rules and would rewrite the block with other content.
   return context.protectedBlocks.reduce(
     (text, block, index) => text.replace(protectedToken(index), () => block),
     serialized,

--- a/injected/responseSerializer.ts
+++ b/injected/responseSerializer.ts
@@ -26,11 +26,20 @@ interface SerializationContext {
   protectedBlocks: string[];
 }
 
+// 收尾時要送哪一份文字。ChatGPT 實測：停止鍵消失的當下回應只有 39 字，1.07 秒後才長到完整的
+// 301 字——「生成中」的訊號比最後一批 render 早結束，只送串流途中快取的文字就會少一截，
+// 極端情況（快取只抓到開頭那行）等於整篇只剩一行。串流是純附加，取較長的那份即可。
+export function longerResponseText(cached: string, fresh: string | null): string {
+  return fresh && fresh.length > cached.length ? fresh : cached;
+}
+
 export function serializeResponseText(root: Element): string {
   const context: SerializationContext = { protectedBlocks: [] };
   const serialized = normalizeDocument(serializeNode(root, context));
+  // 用 replacer function 而不是字串：程式碼區塊裡的 $&、$'、$` 會被 String.replace 當成
+  // 特殊樣式展開，把整段程式碼換成別的內容。
   return context.protectedBlocks.reduce(
-    (text, block, index) => text.replace(protectedToken(index), block),
+    (text, block, index) => text.replace(protectedToken(index), () => block),
     serialized,
   );
 }

--- a/src/__tests__/engine-input.test.ts
+++ b/src/__tests__/engine-input.test.ts
@@ -995,8 +995,9 @@ describe('injected engine input hardening', () => {
     env.responses = [new FakeElement(env.document, 'div', 'opening line')];
     await vi.advanceTimersByTimeAsync(1_000);
 
-    // 最後一批 render 落地，但「生成中」訊號同時消失。快取還停在 opening line，
-    // 下一次 backup poll 要 1000ms 後才到，收尾計時器只剩 100ms——收尾若送快取就少一截。
+    // The last render batch lands as the "still generating" signal clears. The cache still holds
+    // only the opening line, the next backup poll is 1000ms away, and the done timer fires in
+    // 100ms — so finishing from the cache would drop the tail.
     env.responses = [new FakeElement(env.document, 'div', 'opening line and everything after it')];
     env.thinking = false;
     await vi.advanceTimersByTimeAsync(100);

--- a/src/__tests__/engine-input.test.ts
+++ b/src/__tests__/engine-input.test.ts
@@ -974,6 +974,40 @@ describe('injected engine input hardening', () => {
     expect(env.emitted).toContainEqual({ v: 1, action: 'RESPONSE_DONE', provider: 'grok', payload: 'sent response' });
     expect(env.emitted.filter((message) => message.action === 'RESPONSE_DONE')).toHaveLength(1);
   });
+
+  it('collects text that lands after the last cached chunk instead of sending a half answer', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea' });
+    const handler = await installEngine(env);
+    dispatchAdapter(handler, {
+      thinkingDetectors: ['.thinking'],
+      timing: {
+        doneDelayMs: 100,
+        chunkDebounceMs: 0,
+        statusIntervalMs: 1_000_000,
+        backupPollMs: 1_000,
+      },
+    });
+
+    env.thinking = true;
+    send(handler, 'ask something');
+    await flushMicrotasks();
+    env.responses = [new FakeElement(env.document, 'div', 'opening line')];
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    // 最後一批 render 落地，但「生成中」訊號同時消失。快取還停在 opening line，
+    // 下一次 backup poll 要 1000ms 後才到，收尾計時器只剩 100ms——收尾若送快取就少一截。
+    env.responses = [new FakeElement(env.document, 'div', 'opening line and everything after it')];
+    env.thinking = false;
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(env.emitted).toContainEqual({
+      v: 1,
+      action: 'RESPONSE_DONE',
+      provider: 'grok',
+      payload: 'opening line and everything after it',
+    });
+  });
 });
 
 function createEnv(options: { inputKind: 'textarea' | 'contenteditable'; sendButton?: FakeElement | null }): FakeDomEnv {

--- a/src/__tests__/engine-input.test.ts
+++ b/src/__tests__/engine-input.test.ts
@@ -1009,6 +1009,78 @@ describe('injected engine input hardening', () => {
       payload: 'opening line and everything after it',
     });
   });
+
+  it('keeps waiting while a ChatGPT turn has not grown its copy button, then finishes once it does', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea' });
+    const handler = await installEngine(env);
+    const turn = new FakeElement(env.document, 'article');
+    env.detectorElements.set('[data-testid^="conversation-turn-"]', [turn]);
+    dispatchAdapter(handler, {
+      provider: 'chatgpt',
+      thinkingDetectors: ['.thinking'],
+      timing: { doneDelayMs: 100, chunkDebounceMs: 0, statusIntervalMs: 1_000_000, backupPollMs: 1_000 },
+    });
+
+    env.thinking = true;
+    send(handler, 'ask something', 'chatgpt');
+    await flushMicrotasks();
+    env.responses = [new FakeElement(env.document, 'div', 'the full answer')];
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    // The stop button goes away while the turn is still rendering. Finishing here is what used to
+    // cut multi-step answers short, because a pause reads exactly like a finished answer.
+    env.thinking = false;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(env.emitted.filter((message) => message.action === 'RESPONSE_DONE')).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(env.emitted.filter((message) => message.action === 'RESPONSE_DONE')).toHaveLength(0);
+
+    const copyButton = new FakeElement(env.document, 'button');
+    copyButton.setAttribute('data-testid', 'copy-turn-action-button');
+    turn.appendChild(copyButton);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(env.emitted).toContainEqual({
+      v: 1,
+      action: 'RESPONSE_DONE',
+      provider: 'chatgpt',
+      payload: 'the full answer',
+    });
+  });
+
+  it('stops trusting the missing copy button once the response text has gone stale', async () => {
+    vi.useFakeTimers();
+    const env = createEnv({ inputKind: 'textarea' });
+    const handler = await installEngine(env);
+    // A turn that never grows a copy button stands in for the testid being renamed upstream.
+    env.detectorElements.set('[data-testid^="conversation-turn-"]', [new FakeElement(env.document, 'article')]);
+    dispatchAdapter(handler, {
+      provider: 'chatgpt',
+      thinkingDetectors: ['.thinking'],
+      timing: { doneDelayMs: 100, chunkDebounceMs: 0, statusIntervalMs: 1_000_000, backupPollMs: 1_000 },
+    });
+
+    env.thinking = true;
+    send(handler, 'ask something', 'chatgpt');
+    await flushMicrotasks();
+    env.responses = [new FakeElement(env.document, 'div', 'the full answer')];
+    await vi.advanceTimersByTimeAsync(1_000);
+    env.thinking = false;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(env.emitted.filter((message) => message.action === 'RESPONSE_DONE')).toHaveLength(0);
+
+    // Without a ceiling the step would hold open to the host keepalive's 60-minute cap.
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    expect(env.emitted).toContainEqual({
+      v: 1,
+      action: 'RESPONSE_DONE',
+      provider: 'chatgpt',
+      payload: 'the full answer',
+    });
+  });
 });
 
 function createEnv(options: { inputKind: 'textarea' | 'contenteditable'; sendButton?: FakeElement | null }): FakeDomEnv {
@@ -1153,6 +1225,10 @@ class FakeElement {
   querySelector(selector: string): FakeElement | null {
     if (selector === 'img, canvas, video') {
       return this.children.find((child) => ['img', 'canvas', 'video'].includes(child.tagName)) ?? null;
+    }
+    const attribute = /^\[([\w-]+)="(.+)"\]$/.exec(selector);
+    if (attribute) {
+      return this.children.find((child) => child.getAttribute(attribute[1]) === attribute[2]) ?? null;
     }
     return null;
   }

--- a/src/__tests__/responseSerializer.test.ts
+++ b/src/__tests__/responseSerializer.test.ts
@@ -90,8 +90,9 @@ describe('serializeResponseText', () => {
   });
 
   it('restores code blocks verbatim when they contain String.replace substitution patterns', () => {
-    // $&、$'、$` 在替換字串裡有特殊意義，會把整段程式碼換成佔位符或前後文，
-    // 而且外觀正常看不出被竄改，還會原封不動餵進下一棒 AI。
+    // $&, $' and $` are special inside a replacement string and rewrite the block with the
+    // placeholder or the surrounding text. The result still looks like valid code, and it is
+    // forwarded verbatim to the next AI in the workflow.
     const code = 'echo "$&" && echo \'$`\' && echo "$\'" && echo "100$$"';
     const root = element('div', [
       element('p', [text('Run this:')]),
@@ -116,9 +117,10 @@ describe('serializeResponseText', () => {
 
 describe('longerResponseText', () => {
   it('takes the freshly read DOM text only when it adds content to the cache', () => {
-    // 串流是純附加，較長的那份才是完整的一份。
+    // Streaming is append-only, so the longer text is the complete one.
     expect(longerResponseText('opening line', 'opening line and the rest')).toBe('opening line and the rest');
-    // 反向要守住：DOM 已被清空或換掉時不能拿短的那份蓋掉收齊的內容。
+    // The reverse has to hold too: a cleared or replaced container must not overwrite a complete
+    // answer with a shorter read.
     expect(longerResponseText('the whole answer', 'the')).toBe('the whole answer');
     expect(longerResponseText('the whole answer', null)).toBe('the whole answer');
   });

--- a/src/__tests__/responseSerializer.test.ts
+++ b/src/__tests__/responseSerializer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { serializeResponseText } from '../../injected/responseSerializer';
+import { longerResponseText, serializeResponseText } from '../../injected/responseSerializer';
 
 interface FakeNode {
   nodeType: number;
@@ -89,6 +89,18 @@ describe('serializeResponseText', () => {
     expect(serialize(root)).toBe('```\nif x:\n    y()\n```');
   });
 
+  it('restores code blocks verbatim when they contain String.replace substitution patterns', () => {
+    // $&、$'、$` 在替換字串裡有特殊意義，會把整段程式碼換成佔位符或前後文，
+    // 而且外觀正常看不出被竄改，還會原封不動餵進下一棒 AI。
+    const code = 'echo "$&" && echo \'$`\' && echo "$\'" && echo "100$$"';
+    const root = element('div', [
+      element('p', [text('Run this:')]),
+      element('pre', [element('code', [text(code)])]),
+    ]);
+
+    expect(serialize(root)).toBe(`Run this:\n\n\`\`\`\n${code}\n\`\`\``);
+  });
+
   it('ignores non-elements safely and falls back when childNodes is unavailable', () => {
     const root = element('div', [
       { nodeType: 8, textContent: 'hidden comment' },
@@ -99,5 +111,15 @@ describe('serializeResponseText', () => {
 
     expect(serialize(root)).toBe('visible');
     expect(serializeResponseText(bare as unknown as Element)).toBe('native answer');
+  });
+});
+
+describe('longerResponseText', () => {
+  it('takes the freshly read DOM text only when it adds content to the cache', () => {
+    // 串流是純附加，較長的那份才是完整的一份。
+    expect(longerResponseText('opening line', 'opening line and the rest')).toBe('opening line and the rest');
+    // 反向要守住：DOM 已被清空或換掉時不能拿短的那份蓋掉收齊的內容。
+    expect(longerResponseText('the whole answer', 'the')).toBe('the whole answer');
+    expect(longerResponseText('the whole answer', null)).toBe('the whole answer');
   });
 });


### PR DESCRIPTION
Two independent data-integrity bugs in the response collection path. Both were found and fixed first in the browser extension (`teddashh/multi-ai-chat` PR #14), then confirmed to exist here in the same shape. Both silently corrupt the text that gets recorded as an AI's answer, and because a recorded answer is forwarded into the next step of a workflow, the corruption propagates through the run.

## Problem 1 — a response can be recorded truncated

`finishResponse()` sent `lastResponseText`, the value cached during streaming, and never re-read the page.

The "still generating" signal can end before the last render batch lands. Measured on the browser extension against ChatGPT: at the moment the stop button disappeared the answer was 39 characters; 1.07 seconds later it had grown to its full 301 characters. The gap floats with the environment (11 ms on Edge, 1069 ms on Chrome), so the resulting truncation is intermittent rather than reproducible on demand.

In this codebase the window is narrower but reachable. `observeResponses()` returns early while `isThinking()` is true, so during streaming the cache is refreshed only by the backup poll. If the thinking signal clears between the last poll and the done timer firing, the final batch was never cached, and `finishResponse` sends the stale value. In the worst case the cache holds only the opening line, and that one line becomes the whole recorded answer.

## Problem 2 — `$&` in a code block rewrites the code block

`serializeResponseText` swaps each `<pre>` block for a placeholder token and puts the blocks back at the end via `text.replace(protectedToken(index), block)`. Because `block` is a replacement *string*, `$&`, `` $` ``, `$'` and `$$` inside the code are expanded by `String.replace` substitution rules instead of being inserted literally.

A shell snippet containing `$&` comes back as:

```
echo "MAC_PRE_0" && echo '<the entire text preceding the match>
```

`$&` becomes the token itself, `` $` `` becomes everything before the match, and the tail of the block is gone. The output still looks like a normal fenced code block, so nothing signals that the user is reading code that was never sent.

## Fix

**Problem 1** — `finishResponse()` re-reads the DOM and sends the longer of cached and fresh text, via a new `longerResponseText` helper. Streaming is append-only, so the longer text is the complete one; the reverse direction matters too, and the helper keeps the cached value when the fresh read is shorter or null (a cleared or replaced container must not overwrite a complete answer).

This sits in the shared finish path, so it covers all four providers and every route into `finishResponse`, not only the thinking-settled route that already re-read. The two now-redundant re-reads are removed.

The re-read has to happen **before** `cancelResponseWait()`: `getLatestResponseText` filters the send-time baseline through `waitingForResponse` and `responseBaselineEls`, and after the reset it would happily return a message from before the send. There is a comment at the call site recording this.

**Problem 2** — pass a replacer function, `() => block`, so `$` has no special meaning.

## Problem 3 — the stop button alone cannot tell a pause from a finished answer

Re-reading at finish recovers text that is already in the DOM. It cannot recover text the provider has not rendered yet, and the stop button does not stay put until then: it is removed before the last batch, and multi-step answers (search, reasoning) can drop it entirely during an intermediate pause. A pause then looks exactly like a finished answer, and the response is collected early.

A finished ChatGPT turn grows a copy button without needing hover, so an unfinished turn is now a second generating signal. Two constraints shaped how:

**It does not touch `isThinking()`.** `sendStarted()` uses that to decide whether a send landed, and right after a send the last turn is the user message, which carries no copy button. Feeding the turn signal into `sendStarted()` would make a *failed* send look accepted and leave the step waiting for a response that never arrives — and because the keepalive refreshes on thinking reports, it would wait to the 60-minute cap rather than failing fast. Response completion now asks a new `isGenerating()`; `isThinking()` keeps its old meaning for the send path.

**The selectors stay in `engine.ts`, not the adapter JSON.** `thinkingDetectors` is a flat selector array evaluated with `querySelector`, so it cannot express "the last turn is missing this element". It is also pinned: the seed values are frozen by the SPEC 5.1 table and asserted by `scripts/check-adapters.mjs`, so expressing this in adapter data would mean editing policy-owned content. Happy to move it into the schema instead if you would rather own that shape — the mechanism is generic, only the two selectors are provider-specific.

**The signal is bounded**, by `TURN_INCOMPLETE_GRACE_MS` (30s since the response text last changed). If the copy-button testid is renamed upstream, an unbounded signal would latch "still generating" forever and hold the step to the keepalive's 60-minute cap. Past the ceiling the response finishes on the ordinary path, so a stale selector costs one bounded extra wait instead of a hang. This is the one place this PR goes further than the browser-extension fix, which accepted the latch because its 600s backend timeout bounded the damage.

## Verification

- `pnpm verify` — passes: `build:injected`, `typecheck`, `lint`, 53 files / 470 tests, `agent:verify` (22), `check-adapters`. Run on Windows 11.
- Five new tests, each confirmed to **fail without its fix** and pass with it:
  - `engine-input.test.ts` — drives the fake DOM through the exact window (text lands and the thinking signal clears together, next backup poll further away than the done timer). Without the re-read it observes only the cached opening line.
  - `responseSerializer.test.ts` — a code block containing all four substitution patterns. Without the replacer function the assertion sees `echo "MAC_PRE_0"`.
  - `responseSerializer.test.ts` — `longerResponseText` in both directions, including the shorter-fresh and null-fresh cases.
  - `engine-input.test.ts` — the response waits while the ChatGPT turn has no copy button and completes once it appears.
  - `engine-input.test.ts` — a turn that never grows a copy button still finishes after the ceiling. This one fails both when the signal is missing and when the ceiling is removed; I checked the latter by raising `TURN_INCOMPLETE_GRACE_MS` to `Number.MAX_SAFE_INTEGER` and watching it hang.
- The comments added by the first two commits were in Chinese; translated to English in cc69a21 to match `injected/` and `src/__tests__` (review feedback).
- No Rust code touched, so no `cargo` runs were needed.
- Not verified live against a real provider: the truncation window is timing-dependent and does not reproduce on demand. The evidence for the timing gap comes from the browser-extension measurements cited above, where the same code shape was instrumented.

No cookies, tokens, account data, conversation text, provider HTML, or profile files are included, per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
