### PR TITLE
fix: keep code-block line breaks from capture through to display

### DIFF
--- a/injected/responseSerializer.ts
+++ b/injected/responseSerializer.ts
@@ -190,7 +190,7 @@ function preformattedText(element: Element): string {
   const raw = element.textContent ?? '';
   const rendered = (element as { innerText?: unknown }).innerText;
   if (typeof rendered !== 'string' || !rendered.includes('\n')) return raw;
-  return raw.includes('\n') ? raw : rendered;
+  return raw.trim().includes('\n') ? raw : rendered;
 }
 
 function inlineCode(value: string): string {

--- a/injected/responseSerializer.ts
+++ b/injected/responseSerializer.ts
@@ -173,13 +173,24 @@ function serializeTableCellChildren(element: Element): string {
 
 function protectCodeBlock(element: Element, context: SerializationContext): string {
   const codeElement = firstDescendantByTag(element, 'CODE');
-  const code = (codeElement?.textContent ?? element.textContent ?? '').replace(/\r\n?/g, '\n');
+  const code = preformattedText(codeElement ?? element).replace(/\r\n?/g, '\n');
   const language = codeLanguage(codeElement ?? element);
   const longestFence = Math.max(0, ...Array.from(code.matchAll(/`+/g), (match) => match[0].length));
   const fence = '`'.repeat(Math.max(3, longestFence + 1));
   const blockText = `${fence}${language ? language : ''}\n${code}${code.endsWith('\n') ? '' : '\n'}${fence}`;
   const index = context.protectedBlocks.push(blockText) - 1;
   return protectedToken(index);
+}
+
+// A highlighter that gives every code line its own element leaves no newline character behind,
+// so textContent runs the whole block together while each line keeps its indentation. innerText
+// follows the rendered layout and restores those line breaks. It is absent outside a rendered
+// document, and a single-line block needs no repair, so textContent stays the fallback.
+function preformattedText(element: Element): string {
+  const raw = element.textContent ?? '';
+  const rendered = (element as { innerText?: unknown }).innerText;
+  if (typeof rendered !== 'string' || !rendered.includes('\n')) return raw;
+  return raw.includes('\n') ? raw : rendered;
 }
 
 function inlineCode(value: string): string {

--- a/src/__tests__/MarkdownText.test.tsx
+++ b/src/__tests__/MarkdownText.test.tsx
@@ -62,6 +62,17 @@ second line
     expect(html).not.toContain('<strong');
   });
 
+  it('scrolls a fenced block sideways instead of wrapping it', () => {
+    // An ASCII diagram loses its meaning when a long row folds onto the next line, because the
+    // folded part lands under the wrong column. Horizontal scrolling keeps the rows aligned.
+    const html = renderMarkdown('```\nUser ──────────────────────────────────► Memory Manager\n```');
+
+    const preClass = html.match(/<pre class="([^"]*)"/)?.[1] ?? '';
+    expect(preClass.split(' ')).toContain('whitespace-pre');
+    expect(preClass.split(' ')).not.toContain('break-words');
+    expect(preClass.split(' ')).toContain('overflow-x-auto');
+  });
+
   it('renders serialized GFM tables with escaped cell pipes', () => {
     const html = renderMarkdown('| Name | Value |\n| --- | --- |\n| alpha | a\\|b |');
 

--- a/src/__tests__/responseSerializer.test.ts
+++ b/src/__tests__/responseSerializer.test.ts
@@ -102,6 +102,20 @@ describe('serializeResponseText', () => {
     expect(serialize(element('pre', [code]))).toBe('```\nPostgreSQL\n├── users\n└── memories\n```');
   });
 
+  it('ignores incidental outer whitespace when checking line-wrapped code markup', () => {
+    const lines = ['PostgreSQL', '├── users', '└── memories'];
+    const code = Object.assign(
+      element('code', [
+        text('\n  '),
+        ...lines.map((line) => element('span', [text(line)])),
+        text('  \n'),
+      ]),
+      { innerText: lines.join('\n') },
+    );
+
+    expect(serialize(element('pre', [code]))).toBe('```\nPostgreSQL\n├── users\n└── memories\n```');
+  });
+
   it('keeps the literal markup when the code block already carries its own newlines', () => {
     // innerText reports what the layout shows, which can drop leading indentation. Markup that
     // already has the line breaks is the more faithful source, so it wins.

--- a/src/__tests__/responseSerializer.test.ts
+++ b/src/__tests__/responseSerializer.test.ts
@@ -89,6 +89,29 @@ describe('serializeResponseText', () => {
     expect(serialize(root)).toBe('```\nif x:\n    y()\n```');
   });
 
+  it('recovers code-block line breaks from the rendered layout when the markup has none', () => {
+    // A highlighter that wraps every line in its own element leaves no newline character in the
+    // markup. textContent then joins the lines into one run-on string that still carries their
+    // indentation, which flattens an ASCII diagram into a single unreadable line in the export.
+    const lines = ['PostgreSQL', '├── users', '└── memories'];
+    const code = Object.assign(
+      element('code', lines.map((line) => element('span', [text(line)]))),
+      { innerText: lines.join('\n') },
+    );
+
+    expect(serialize(element('pre', [code]))).toBe('```\nPostgreSQL\n├── users\n└── memories\n```');
+  });
+
+  it('keeps the literal markup when the code block already carries its own newlines', () => {
+    // innerText reports what the layout shows, which can drop leading indentation. Markup that
+    // already has the line breaks is the more faithful source, so it wins.
+    const code = Object.assign(element('code', [text('first()\n    second()')]), {
+      innerText: 'first()\nsecond()',
+    });
+
+    expect(serialize(element('pre', [code]))).toBe('```\nfirst()\n    second()\n```');
+  });
+
   it('restores code blocks verbatim when they contain String.replace substitution patterns', () => {
     // $&, $' and $` are special inside a replacement string and rewrite the block with the
     // placeholder or the surrounding text. The result still looks like valid code, and it is

--- a/src/ui/MarkdownText.tsx
+++ b/src/ui/MarkdownText.tsx
@@ -430,7 +430,7 @@ function renderBlocks(text: string): ReactNode[] {
       blocks.push(
         <pre
           key={key}
-          className="my-3 overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-zinc-100 p-3 text-sm leading-relaxed dark:bg-zinc-900"
+          className="my-3 overflow-x-auto whitespace-pre rounded-md bg-zinc-100 p-3 text-sm leading-relaxed dark:bg-zinc-900"
         >
           <code className="font-mono">{codeLines.join('\n')}</code>
         </pre>,


### PR DESCRIPTION
## Problem

A provider answer containing an ASCII diagram came through as one run-on line. The indentation of
every row was still there, but the line breaks were gone:

```
PostgreSQL ├── users ├── memories ├── conversations └── messagespgvector └── memories.embedding
```

A wide diagram that did survive capture was scrambled a second time on screen, because long rows
folded onto the next line and landed under the wrong column.

## Cause

Two separate defects that both flatten the same content.

**Capture.** `protectCodeBlock()` read the block through `textContent`. A highlighter that wraps
every code line in its own element leaves no newline character in the markup, so `textContent`
concatenates the rows while the spaces inside each row survive. That is exactly the shape observed:
indentation intact, `\n` missing. The line breaks exist only in the rendered layout.

**Display.** The fenced block rendered with `whitespace-pre-wrap break-words`. The element already
had `overflow-x-auto`, but wrapping wins over it, so a row wider than the pane folded instead of
scrolling.

## Fix

- Read a code block through `innerText`, which follows the rendered layout and reports the line
  breaks. Markup that already carries newlines still wins, because `innerText` can drop leading
  indentation, and the verbatim markup is the more faithful source. `textContent` remains the
  fallback outside a rendered document.
- Render fenced blocks with `whitespace-pre` so a long row scrolls in the container that was
  already there instead of folding.

The serializer feeds the Markdown export, so an exported answer now keeps a diagram the provider's
own page had already collapsed.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 54 files, 476 tests passing
- Two regression tests added: one pins the recovery of line breaks from the rendered layout, one
  pins that markup carrying its own newlines is preferred over `innerText`. A third pins that a
  fenced block scrolls rather than wraps.
- Verified by hand in a release build against a live provider answer containing ASCII diagrams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
