### PR TITLE
fix(ui): stop the chip jump and the replay drawer from hiding the toolbar

### DIFF
--- a/src/__tests__/transcriptScroll.test.ts
+++ b/src/__tests__/transcriptScroll.test.ts
@@ -19,28 +19,33 @@ describe('transcript scrolling', () => {
     expect(scrollTo).toHaveBeenCalledWith({ top: 2_400, behavior: 'auto' });
   });
 
-  const fakeBubble = () => ({
-    scrollIntoView: vi.fn(),
+  const fakeBubble = (top = 0) => ({
+    getBoundingClientRect: () => ({ top }),
     classList: { add: vi.fn(), remove: vi.fn() },
+  });
+
+  const fakeTranscript = (bubbles: ReturnType<typeof fakeBubble>[], scrollTop = 0) => ({
+    scrollTop,
+    scrollTo: vi.fn(),
+    getBoundingClientRect: () => ({ top: 100 }),
+    querySelectorAll: vi.fn((selector: string) => (selector === 'article[data-provider="chatgpt"]' ? bubbles : [])),
   });
 
   it('jumps to the latest message of the clicked provider so the user sees its part of the conversation', () => {
     vi.useFakeTimers();
-    const older = fakeBubble();
-    const latest = fakeBubble();
-    const container = {
-      querySelectorAll: vi.fn((selector: string) => (selector === 'article[data-provider="chatgpt"]' ? [older, latest] : [])),
-    };
+    const older = fakeBubble(150);
+    const latest = fakeBubble(940);
+    const container = fakeTranscript([older, latest], 300);
 
     expect(scrollTranscriptToProviderMessage(container, 'chatgpt')).toBe(true);
-    expect(older.scrollIntoView).not.toHaveBeenCalled();
-    expect(latest.scrollIntoView).toHaveBeenCalledWith({ block: 'start' });
+    // The container scrolls to the latest bubble and nothing outside it moves, so the toolbar stays put.
+    expect(container.scrollTo).toHaveBeenCalledWith({ top: 1_140 });
   });
 
   it('flashes a temporary highlight on the target message so the user can spot it', () => {
     vi.useFakeTimers();
     const bubble = fakeBubble();
-    const container = { querySelectorAll: () => [bubble] };
+    const container = fakeTranscript([bubble]);
 
     scrollTranscriptToProviderMessage(container, 'chatgpt');
 
@@ -53,7 +58,7 @@ describe('transcript scrolling', () => {
   it('restarts the full highlight duration when the same provider is clicked again', () => {
     vi.useFakeTimers();
     const bubble = fakeBubble();
-    const container = { querySelectorAll: () => [bubble] };
+    const container = fakeTranscript([bubble]);
 
     scrollTranscriptToProviderMessage(container, 'chatgpt');
     vi.advanceTimersByTime(1_000);
@@ -67,7 +72,7 @@ describe('transcript scrolling', () => {
 
   it('leaves the transcript alone when the provider never joined the conversation', () => {
     vi.useFakeTimers();
-    const container = { querySelectorAll: () => [] };
+    const container = fakeTranscript([]);
 
     expect(scrollTranscriptToProviderMessage(container, 'gemini')).toBe(false);
   });

--- a/src/ui/ReplayPanel.tsx
+++ b/src/ui/ReplayPanel.tsx
@@ -180,7 +180,7 @@ export class ReplayPanel extends Component<ReplayPanelProps, ReplayPanelState> {
               <div>
                 <h4 className="text-xs font-semibold uppercase text-zinc-700 dark:text-zinc-300">{this.t('replay.lastRun')}</h4>
                 <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
-                  {lastSnapshot ? `${lastSnapshot.graphId} - ${lastSnapshot.createdAt}` : this.t('replay.noInMemorySnapshot')}
+                  {lastSnapshot ? `${lastSnapshot.graphId} - ${localTime(lastSnapshot.createdAt, this.locale())}` : this.t('replay.noInMemorySnapshot')}
                 </p>
               </div>
               {lastSnapshot ? (
@@ -221,14 +221,14 @@ export class ReplayPanel extends Component<ReplayPanelProps, ReplayPanelState> {
               </div>
             ) : null}
             {!loadingStored && storedSnapshots.length > 0 ? (
-              <div className="divide-y divide-zinc-200 dark:divide-zinc-800 border border-zinc-200 dark:border-zinc-800">
+              <div className="max-h-72 overflow-y-auto divide-y divide-zinc-200 dark:divide-zinc-800 border border-zinc-200 dark:border-zinc-800">
                 {storedSnapshots.map((snapshot) => {
                   const replaySource: ReplaySource = { kind: 'stored', snapshotId: snapshot.id, info: snapshot };
                   return (
                     <div key={snapshot.id} className="grid gap-2 p-2 text-xs sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
                       <div className="min-w-0">
                         <div className="truncate font-medium text-zinc-900 dark:text-zinc-100">{snapshot.graphId ?? this.t('replay.unknownGraph')}</div>
-                        <div className="truncate text-zinc-500 dark:text-zinc-500">{snapshot.createdAt ?? this.t('replay.createdTimeUnknown')}</div>
+                        <div className="truncate text-zinc-500 dark:text-zinc-500">{localTime(snapshot.createdAt, this.locale()) ?? this.t('replay.createdTimeUnknown')}</div>
                       </div>
                       <div className="flex gap-2">
                         <button
@@ -426,6 +426,14 @@ function sourceKey(source: ReplaySource): string {
 
 function sourceLabel(source: ReplaySource, locale: Locale): string {
   return source.kind === 'last' ? t('replay.sourceLastRun', locale) : source.snapshotId;
+}
+
+// Snapshots are stored as UTC ISO strings; showing them raw makes every row read as a foreign
+// clock. Fall back to the raw string when the value is missing or unparseable.
+function localTime(value: string | undefined, locale: Locale): string | undefined {
+  const parsed = Date.parse(value ?? '');
+  if (!Number.isFinite(parsed)) return value;
+  return new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'medium' }).format(parsed);
 }
 
 function snapshotTime(snapshot: StoredSnapshotInfo): number {

--- a/src/ui/transcriptScroll.ts
+++ b/src/ui/transcriptScroll.ts
@@ -21,12 +21,13 @@ const HIGHLIGHT_DURATION_MS = 1_600;
 const highlightTimers = new WeakMap<TranscriptProviderBubble, ReturnType<typeof setTimeout>>();
 
 export interface TranscriptProviderBubble {
-  scrollIntoView(options?: ScrollIntoViewOptions): void;
+  getBoundingClientRect(): { top: number };
   classList: { add(token: string): void; remove(token: string): void };
 }
 
-export interface TranscriptProviderLookup {
+export interface TranscriptProviderLookup extends Pick<TranscriptScrollContainer, 'scrollTop' | 'scrollTo'> {
   querySelectorAll(selector: string): ArrayLike<TranscriptProviderBubble>;
+  getBoundingClientRect(): { top: number };
 }
 
 export interface TranscriptSpyBubble {
@@ -72,7 +73,9 @@ export function scrollTranscriptToProviderMessage(container: TranscriptProviderL
   const bubbles = container.querySelectorAll(`article[data-provider="${provider}"]`);
   const last = bubbles[bubbles.length - 1];
   if (!last) return false;
-  last.scrollIntoView({ block: 'start' });
+  // scrollIntoView also scrolls every scrollable ancestor, which slid the workspace toolbar —
+  // and the replay toggle in it — out of the window with no way back. Scroll the transcript alone.
+  container.scrollTo({ top: container.scrollTop + last.getBoundingClientRect().top - container.getBoundingClientRect().top });
   last.classList.add(HIGHLIGHT_CLASS);
   const previousTimer = highlightTimers.get(last);
   if (previousTimer !== undefined) clearTimeout(previousTimer);


### PR DESCRIPTION
## Problem

Clicking a provider chip can leave the app with no visible way back: the
conversation toolbar — mode badge, export, archive, replay toggle, settings —
scrolls out of the window and nothing scrolls it back. The replay drawer reaches
the same dead end on its own once a few dozen snapshots have accumulated.

## Cause

Two separate paths to one symptom:

- `scrollTranscriptToProviderMessage` jumps to the bubble with
  `scrollIntoView`, which scrolls **every** scrollable ancestor, not just the
  transcript. The workspace shifts up and the toolbar leaves the viewport.
- The stored-snapshot list in `ReplayPanel` has no height cap, so a long history
  makes the drawer taller than the workspace and pushes the toolbar off screen —
  including the toggle that would close the drawer.

## Fix

- Scroll the transcript container itself, by its own `scrollTop` plus the offset
  between the bubble and the container. Nothing outside the transcript moves.
- Cap the snapshot list (`max-h-72 overflow-y-auto`) so the drawer stays inside
  the workspace however long the history gets.

While in that list: snapshot times were printed as raw UTC ISO strings
(`2026-07-23T09:39:36.276Z`). They now render through
`Intl.DateTimeFormat(locale)`, falling back to the raw string when the value is
missing or unparseable.

## Verification

- `npm run typecheck` clean.
- `npx vitest run`: 54 files / 473 tests pass. The chip-jump test now asserts the
  container's own `scrollTo` target instead of a `scrollIntoView` call, so it
  fails if ancestor scrolling comes back.
- Checked in the running desktop app: clicking a chip moves only the transcript,
  the drawer keeps its own scrollbar, and the toggle stays reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
