### PR TITLE
fix(ui): keep the preset detail panel layout the same for every preset

### DIFF
--- a/src/ui/PresetCatalog.tsx
+++ b/src/ui/PresetCatalog.tsx
@@ -51,12 +51,12 @@ export function PresetCatalog({
         activePresetId,
       })}
       {detailPreset ? (
-        <div className="ai-sister-preset-detail flex flex-wrap items-start justify-between gap-3 rounded border border-sky-200 bg-sky-50 px-3 py-2 text-xs dark:border-sky-900 dark:bg-sky-950/30">
-          <div className="min-w-0 flex-1">
-            <div className="font-semibold text-sky-900 dark:text-sky-100">{t(detailPreset.displayNameKey, locale)}</div>
-            <p className="mt-1 leading-relaxed text-zinc-700 dark:text-zinc-300">{t(detailPreset.descriptionKey, locale)}</p>
-          </div>
-          <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[0.6875rem] text-zinc-600 dark:bg-zinc-900 dark:text-zinc-300">
+        <div className="ai-sister-preset-detail rounded border border-sky-200 bg-sky-50 px-3 py-2 text-xs dark:border-sky-900 dark:bg-sky-950/30">
+          <div className="font-semibold text-sky-900 dark:text-sky-100">{t(detailPreset.displayNameKey, locale)}</div>
+          <p className="mt-1 leading-relaxed text-zinc-700 dark:text-zinc-300">{t(detailPreset.descriptionKey, locale)}</p>
+          {/* Own row, wrapping: the cost label runs from a few words to a full line
+              (brainstorm), so an inline pill laid the panel out differently per preset. */}
+          <span className="mt-2 inline-block rounded-full bg-white px-2 py-1 text-[0.6875rem] leading-relaxed text-zinc-600 dark:bg-zinc-900 dark:text-zinc-300">
             {t(detailPreset.costLabelKey, locale)}
           </span>
         </div>


### PR DESCRIPTION
## Problem

The preset detail panel — the box that opens under the preset grid when you pick a mode — renders in a different shape for **Brainstorm** than for the other five presets. In the sidebar layout the cost label either wraps onto its own line at an odd offset or stretches the panel, so the panel visibly changes shape as you click through the presets.

## Cause

`PresetCatalog.tsx` laid the panel out as `flex flex-wrap items-start justify-between`, with name + description on the left and the cost label as a `shrink-0` pill on the right. That works only while the label is short. The label is a line of prose whose length varies a lot per preset:

- `preset.consult.costLabel` — "4 roles · 4 logins · ~2 min · low RAM"
- `preset.brainstorm.costLabel` — "4 seats · 4 logins · 48 replies · ~45–90 min · very high RAM"

`shrink-0` means the long one cannot give ground, so it either wraps to its own row (leaving the description column short and ragged) or forces the panel wider than its neighbours.

## Fix

Put the cost label on its own row under the description and let it wrap inside the pill (`inline-block`, no `shrink-0`). Every preset now renders the same shape and the panel no longer changes width with the label. No string or behaviour change — layout only.

## Verification

- `npm run typecheck` — pass
- `npx vitest run` — 473 passed / 54 files
- Manual: opened each of the six preset detail panels in the sidebar layout on a Windows 11 dev build; all six render identically now, and brainstorm's label wraps inside the pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
