### PR TITLE
feat(ui): collapse the conversation history when a new conversation starts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1862,7 +1862,10 @@ export default function App() {
               confirmDeleteConversation: translate('conversation.deleteConfirm'),
             }}
             onToggle={() => setSessionSidebarCollapsed((current) => !current)}
-            onNewConversation={startNewConversation}
+            onNewConversation={() => {
+              startNewConversation();
+              setSessionSidebarCollapsed(true);
+            }}
             onSelectSession={selectConversationSession}
             onDeleteSession={deleteConversationSession}
           />


### PR DESCRIPTION
## Problem

Pressing **+ New conversation** leaves the conversation history list expanded, holding 12rem of window width on a list that has nothing useful to show at that moment: the freshly created session is empty and already selected, and the next thing the user does is pick a mode or start typing. The list has to be collapsed by hand every time.

## Cause

`onNewConversation` was wired straight to `startNewConversation`, which resets mode, messages, targets and trace but never touches the sidebar's collapsed state.

## Fix

Collapse the sidebar from the sidebar button's handler:

```tsx
onNewConversation={() => {
  startNewConversation();
  setSessionSidebarCollapsed(true);
}}
```

Deliberately **not** inside `startNewConversation()`. That function also runs at launch when the "start a new conversation on startup" setting is on, and collapsing there would overwrite the user's saved collapsed/expanded preference on every boot. Hooking the button keeps the startup path untouched.

The toggle button expands the list again as before, and the state is persisted through the existing `saveSessionSidebarCollapsed` effect.

If you would rather have this behind a setting than as the default, say so and I will move it — it is one more boolean in `AppSettings` plus a checkbox.

## Verification

- `npm run typecheck` — pass
- `npx vitest run` — 473 passed / 54 files
- Manual on a Windows 11 dev build: **+ New conversation** collapses the list; the toggle re-expands it; with "start a new conversation on startup" enabled, a relaunch restores the saved sidebar state instead of forcing it collapsed.

No automated test added: the change is one state setter in a click handler, and asserting it needs a full `App` render, which this suite does not currently do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
