### PR TITLE
perf(transcript): memoise Markdown rendering so polling stops re-parsing finished messages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AI_PROVIDERS, CHAT_MODES, DEFAULT_FREE_TARGET_PROVIDERS } from '../shared/constants';
 import type { AIProvider, BridgeMessage, ChatMode, ProviderState, WorkflowPresetId } from '../shared/types';
 import { startBridgePull, resetProviderBootState } from './bridge/pull';
@@ -2222,6 +2222,48 @@ function adapterNoticeText(notice: AdapterNotice): string {
   return `${provider}: ${notice.message || notice.kind}`;
 }
 
+// One transcript row. Provider polling replaces the `states` object every
+// POLL_PULL_MS, which re-renders ChatArea; memoising on the three values a row
+// actually reads keeps finished messages from re-parsing their Markdown.
+const TranscriptMessage = memo(function TranscriptMessage({
+  message,
+  locale,
+  thinking,
+}: {
+  message: Bubble;
+  locale: Locale;
+  thinking: boolean;
+}) {
+  const p = message.provider;
+  const isProvider = typeof p === 'string' && p in AI_PROVIDERS;
+  const statusLabel =
+    message.role === 'ai' && !message.final ? translateKey(thinking ? 'chat.thinking' : 'chat.streaming', locale) : '';
+
+  return (
+    <article
+      className="ai-sister-message border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900 p-3"
+      data-provider={isProvider ? p : undefined}
+    >
+      <div className="mb-1 flex items-center gap-2">
+        {isProvider ? <AiSisterAvatar provider={p as AIProvider} active={thinking} size="md" /> : null}
+        <div className="text-xs uppercase text-zinc-500 dark:text-zinc-500">
+          {bubbleAuthorLabel(message)}
+          {message.modeRole ? ` · ${message.modeRole}` : ''}
+          {statusLabel ? ` ${statusLabel}` : ''}
+        </div>
+      </div>
+      {thinking ? (
+        <div className="whitespace-pre-wrap text-sm italic text-zinc-500 dark:text-zinc-500">{translateKey('chat.thinking', locale)}</div>
+      ) : (
+        <div className="text-sm">
+          <MarkdownText text={message.content} />
+        </div>
+      )}
+      {message.truncated ? <div className="mt-2 text-xs text-amber-700 dark:text-amber-300">{translateKey('chat.truncated', locale)}</div> : null}
+    </article>
+  );
+});
+
 export function ChatArea({
   messages,
   locale,
@@ -2249,33 +2291,13 @@ export function ChatArea({
       {messages.map((message) => {
         const p = message.provider;
         const isProvider = typeof p === 'string' && p in AI_PROVIDERS;
-        const thinking = isProvider && !message.final && states[p as AIProvider]?.thinking === true;
-        const statusLabel =
-          message.role === 'ai' && !message.final ? translateKey(thinking ? 'chat.thinking' : 'chat.streaming', locale) : '';
-
         return (
-          <article
+          <TranscriptMessage
             key={message.id}
-            className="ai-sister-message border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900 p-3"
-            data-provider={isProvider ? p : undefined}
-          >
-            <div className="mb-1 flex items-center gap-2">
-              {isProvider ? <AiSisterAvatar provider={p as AIProvider} active={thinking} size="md" /> : null}
-              <div className="text-xs uppercase text-zinc-500 dark:text-zinc-500">
-                {bubbleAuthorLabel(message)}
-                {message.modeRole ? ` · ${message.modeRole}` : ''}
-                {statusLabel ? ` ${statusLabel}` : ''}
-              </div>
-            </div>
-            {thinking ? (
-              <div className="whitespace-pre-wrap text-sm italic text-zinc-500 dark:text-zinc-500">{translateKey('chat.thinking', locale)}</div>
-            ) : (
-              <div className="text-sm">
-                <MarkdownText text={message.content} />
-              </div>
-            )}
-            {message.truncated ? <div className="mt-2 text-xs text-amber-700 dark:text-amber-300">{translateKey('chat.truncated', locale)}</div> : null}
-          </article>
+            message={message}
+            locale={locale}
+            thinking={isProvider && !message.final && states[p as AIProvider]?.thinking === true}
+          />
         );
       })}
     </div>

--- a/src/__tests__/MarkdownText.test.tsx
+++ b/src/__tests__/MarkdownText.test.tsx
@@ -97,4 +97,12 @@ second line
     expect(html).not.toContain('href="data:');
     expect(html).not.toContain('target="_blank"');
   });
+
+  it('stays memoised so poll-driven re-renders do not re-parse finished messages', () => {
+    // Provider polling replaces the states object every POLL_PULL_MS while a
+    // workflow runs, re-rendering the whole transcript. Markdown parsing is the
+    // dominant cost there, so dropping memo would silently regress long
+    // Roundtable and Brainstorm runs.
+    expect((MarkdownText as unknown as { $$typeof: symbol }).$$typeof).toBe(Symbol.for('react.memo'));
+  });
 });

--- a/src/ui/MarkdownText.tsx
+++ b/src/ui/MarkdownText.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { memo, type ReactNode } from 'react';
 
 export interface MarkdownTextProps {
   text: string;
@@ -568,6 +568,11 @@ function renderBlocks(text: string): ReactNode[] {
   return blocks;
 }
 
-export function MarkdownText({ text }: MarkdownTextProps) {
+function MarkdownTextView({ text }: MarkdownTextProps) {
   return <div className="min-w-0 break-words leading-relaxed">{renderBlocks(text)}</div>;
 }
+
+// Rendering is a pure function of `text`, and parsing dominates transcript cost.
+// Provider polling re-renders the conversation every POLL_PULL_MS while a workflow
+// runs, so without memoisation every finished message is re-parsed twice a second.
+export const MarkdownText = memo(MarkdownTextView);


### PR DESCRIPTION
## Summary

- Transcript Markdown rendering is memoised so provider polling stops re-parsing finished messages.

  While a workflow runs, provider pulls replace the `states` object every `POLL_PULL_MS`
  (500 ms). That re-renders `ChatArea`, which re-parses the Markdown of *every* message in
  the transcript — including finished ones whose content cannot change. `MarkdownText` is a
  pure function of `text` (no hooks, no context, no globals), so this work is entirely redundant.

  This wraps `MarkdownText` in `memo` and extracts each transcript row into a memoised
  `TranscriptMessage` that receives only the three values a row reads (`message`, `locale`,
  `thinking`). `FocusPane` and `ProcessTrace` also render `MarkdownText` and benefit from the
  same change.

  The memo boundary is safe because every message update is already immutable
  (`setMessages` uses `{ ...bubble, content }` and returns untouched bubbles by reference),
  so a streaming message still gets a fresh reference and re-renders, while finished
  messages keep theirs and are skipped.

- Affected: the conversation transcript surface. No provider, adapter, workflow, or security
  boundary changes. No Rust changes. No behaviour change.

### Measurements

Re-rendering an unchanged transcript on a fresh `states` object, via `react-dom/client`
under jsdom (jsdom added locally for the measurement only, not committed):

| Preset | Before | After |
|---|---|---|
| Roundtable (20 turns, 27 KB) | 9.53 ms/pass | 0.10 ms/pass |
| Brainstorm (48 contributions, 64 KB) | 20.08 ms/pass | 0.12 ms/pass |

At two passes per second that is 4.0% → 0.02% of one core for Brainstorm, and it removes a
~20 ms main-thread block every 500 ms during long runs — the interval where typing and
scrolling felt stuttery.

A regression test pins the memo boundary so it cannot be silently dropped.

I understand the project is in maintenance mode and that this is not a compatibility,
security, or build-breakage fix. Happy to close it if it is out of scope.

## Validation

- [x] `pnpm verify`
- [ ] `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` when Rust changed — n/a, no Rust changes
- [ ] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` when Rust changed — n/a, no Rust changes
- [x] Relevant manual smoke steps are listed with platform and app/adapter versions
- [x] No cookies, tokens, account data, conversation text, provider HTML, or local profile files are included

### Manual smoke steps

Platform: Windows 11 Pro 26100, x64. Built from this branch with Rust 1.98.0 / MSVC 2022.
App version: v1.8.5 tree. Adapters unchanged.

Built this branch locally (`pnpm tauri build`, 3m08s, exit 0) and ran the produced
`multi-ai-chat-desktop.exe` directly:

- App launches, main window titles correctly, and stays up (checked to 35 s) with no crash.
- Idle CPU stays flat (0.3 s accumulated over the run) and RSS holds at ~50.8 MB, so the
  memo boundary introduces no render loop.
- `pnpm verify` is green on this branch: 486 vitest tests (485 existing plus the new memo
  regression test), 22 agent contract tests, typecheck, lint, and the adapter seed check.

Scope note, stated plainly: I did not drive a full multi-provider workflow end to end on this
build, so the timings above come from the jsdom harness rather than from a live Roundtable or
Brainstorm run. The rendering path itself is covered by the existing transcript tests.

## Adapter changes

Not applicable — no `adapters/*.json` changes.
