### PR TITLE
chore(security): update fast-uri to patched release

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -989,8 +989,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2203,7 +2203,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2443,7 +2443,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fastq@1.20.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Refresh the lockfile-only resolution of the development-time Ajv dependency fast-uri from 3.1.5 to patched 3.1.7.
- Address all four currently open High Dependabot alerts for fast-uri (GHSA-5jgf-p345-68v8, GHSA-fph4-wmhf-6fwf, GHSA-f65p-4m7j-42xc, and GHSA-jqff-g426-hqxp).
- Keep package.json, Ajv 8.20.0, runtime dependencies, adapters, and provider permission boundaries unchanged.

This dependency is used by repository schema validation and tests; it is not bundled into the desktop runtime. The patch is isolated so GitHub can verify and close the alerts independently of #81.

## Validation

- [x] pnpm install --frozen-lockfile
- [x] pnpm verify (54 test files, 488 tests; typecheck, lint, 22 agent tests, adapter schema checks)
- [x] pnpm audit --prod: No known vulnerabilities found
- [x] pnpm audit: No known vulnerabilities found
- [x] Diff is limited to pnpm-lock.yaml (fast-uri 3.1.5 -> 3.1.7 and matching integrity/snapshot entries)
- [x] No cookies, tokens, account data, conversation text, provider HTML, or local profile files are included

## Adapter changes

Not applicable; no adapter changes.